### PR TITLE
Allowed TransactionReceipt.root to be null and added TransactionReceipt.status

### DIFF
--- a/providers/json-rpc-provider.js
+++ b/providers/json-rpc-provider.js
@@ -65,7 +65,7 @@ utils.defineProperty(JsonRpcProvider.prototype, 'send', function(method, params)
     var request = {
         method: method,
         params: params,
-        id: this.chainId,
+        id: 42,
         jsonrpc: "2.0"
     };
     return Provider.fetchJSON(this.url, JSON.stringify(request), getResult);

--- a/providers/json-rpc-provider.js
+++ b/providers/json-rpc-provider.js
@@ -65,7 +65,7 @@ utils.defineProperty(JsonRpcProvider.prototype, 'send', function(method, params)
     var request = {
         method: method,
         params: params,
-        id: 42,
+        id: this.chainId,
         jsonrpc: "2.0"
     };
     return Provider.fetchJSON(this.url, JSON.stringify(request), getResult);

--- a/providers/provider.js
+++ b/providers/provider.js
@@ -279,7 +279,8 @@ function checkTransactionReceiptLog(log) {
 var formatTransactionReceipt = {
     contractAddress: allowNull(utils.getAddress, null),
     transactionIndex: checkNumber,
-    root: checkHash,
+    root: allowNull(checkHash, null),
+    status: allowNull(utils.bigNumberify, null),
     gasUsed: utils.bigNumberify,
     logsBloom: utils.hexlify,
     blockHash: checkHash,
@@ -495,6 +496,9 @@ utils.defineProperty(Provider, 'chainId', {
     homestead: 1,
     morden: 2,
     ropsten: 3,
+    rinkeby: 4,
+    kovan: 42,
+    localDev: 100
 });
 
 //utils.defineProperty(Provider, 'isProvider', function(object) {

--- a/providers/provider.js
+++ b/providers/provider.js
@@ -497,8 +497,7 @@ utils.defineProperty(Provider, 'chainId', {
     morden: 2,
     ropsten: 3,
     rinkeby: 4,
-    kovan: 42,
-    localDev: 100
+    kovan: 42
 });
 
 //utils.defineProperty(Provider, 'isProvider', function(object) {

--- a/providers/provider.js
+++ b/providers/provider.js
@@ -260,11 +260,10 @@ function checkTransactionRequest(transaction) {
 }
 
 var formatTransactionReceiptLog = {
-    transactionLogIndex: checkNumber,
+    transactionIndex: checkNumber,
     blockNumber: checkNumber,
     transactionHash: checkHash,
     address: utils.getAddress,
-    type: checkString,
     topics: arrayOf(checkHash),
     transactionIndex: checkNumber,
     data: utils.hexlify,


### PR DESCRIPTION
Post the Byzantium fork the root is no longer used and the status field has been added to the TransactionReceipt