### PR TITLE
Updated validation of TransactionReceipt so it'll work with Infura

### DIFF
--- a/providers/provider.js
+++ b/providers/provider.js
@@ -260,11 +260,10 @@ function checkTransactionRequest(transaction) {
 }
 
 var formatTransactionReceiptLog = {
-    transactionLogIndex: checkNumber,
+    transactionIndex: checkNumber,
     blockNumber: checkNumber,
     transactionHash: checkHash,
     address: utils.getAddress,
-    type: checkString,
     topics: arrayOf(checkHash),
     transactionIndex: checkNumber,
     data: utils.hexlify,


### PR DESCRIPTION
I had to make this change in order to a get transaction receipt using the Infura provider on mainnet

Interestingly my dev Parity node does not return logs in in a transaction receipt so did not have the same problem as Infura.

I haven't been able to test this against a local dev instance of Geth as I can't get transaction signing to work. That's a separate problem, though.

The changes match the JavaScript API doco
https://github.com/ethereum/wiki/wiki/JavaScript-API#watch-callback-return-value