### PR TITLE
Remove double declaration of  transactionIndex

### DIFF
--- a/providers/provider.js
+++ b/providers/provider.js
@@ -268,7 +268,6 @@ var formatTransactionReceiptLog = {
     // @TODO: Next major release remove this
     type: allowNull(checkString),
     topics: arrayOf(checkHash),
-    transactionIndex: checkNumber,
     data: utils.hexlify,
     logIndex: checkNumber,
     blockHash: checkHash,


### PR DESCRIPTION
This little guy nearly broke my react native app's production build by sneaking past me. 😬