### PR TITLE
Strip leading hex zeros on block number

### DIFF
--- a/providers/etherscan-provider.js
+++ b/providers/etherscan-provider.js
@@ -8,16 +8,10 @@ var utils = (function() {
         defineProperty: require('ethers-utils/properties.js').defineProperty,
 
         hexlify: convert.hexlify,
+
+        stripHexZeros: convert.stripHexZeros,
     };
 })();
-
-// @TODO: Add this to utils; lots of things need this now
-function stripHexZeros(value) {
-    while (value.length > 3 && value.substring(0, 3) === '0x0') {
-        value = '0x' + value.substring(3);
-    }
-    return value;
-}
 
 function getTransactionString(transaction) {
     var result = [];
@@ -25,7 +19,7 @@ function getTransactionString(transaction) {
         if (transaction[key] == null) { continue; }
         var value = utils.hexlify(transaction[key]);
         if ({ gasLimit: true, gasPrice: true, nonce: true, value: true }[key]) {
-            value = stripHexZeros(value);
+            value = utils.stripHexZeros(value);
         }
         result.push(key + '=' + value);
     }
@@ -140,8 +134,8 @@ utils.defineProperty(EtherscanProvider.prototype, 'perform', function(method, pa
 
         case 'getStorageAt':
             url += '/api?module=proxy&action=eth_getStorageAt&address=' + params.address;
-            url += '&position=' + stripHexZeros(params.position);
-            url += '&tag=' + stripHexZeros(params.blockTag) + apiKey;
+            url += '&position=' + utils.stripHexZeros(params.position);
+            url += '&tag=' + utils.stripHexZeros(params.blockTag) + apiKey;
             return Provider.fetchJSON(url, null, getJsonResult);
 
         case 'sendTransaction':
@@ -152,7 +146,7 @@ utils.defineProperty(EtherscanProvider.prototype, 'perform', function(method, pa
 
         case 'getBlock':
             if (params.blockTag) {
-                url += '/api?module=proxy&action=eth_getBlockByNumber&tag=' + stripHexZeros(params.blockTag);
+                url += '/api?module=proxy&action=eth_getBlockByNumber&tag=' + utils.stripHexZeros(params.blockTag);
                 url += '&boolean=false';
                 url += apiKey;
                 return Provider.fetchJSON(url, null, getJsonResult);

--- a/providers/json-rpc-provider.js
+++ b/providers/json-rpc-provider.js
@@ -11,6 +11,8 @@ var utils = (function() {
 
         hexlify: convert.hexlify,
         isHexString: convert.isHexString,
+
+        stripHexZeros: convert.stripHexZeros,
     }
 })();
 
@@ -25,13 +27,6 @@ function getResult(payload) {
     return payload.result;
 }
 
-function stripHexZeros(value) {
-    while (value.length > 3 && value.substring(0, 3) === '0x0') {
-        value = '0x' + value.substring(3);
-    }
-    return value;
-}
-
 function getTransaction(transaction) {
     var result = {};
 
@@ -42,7 +37,7 @@ function getTransaction(transaction) {
     // Some nodes (INFURA ropsten; INFURA mainnet is fine) don't like extra zeros.
     ['gasLimit', 'gasPrice', 'nonce', 'value'].forEach(function(key) {
         if (!result[key]) { return; }
-        result[key] = stripHexZeros(result[key]);
+        result[key] = utils.stripHexZeros(result[key]);
     });
 
     return result;
@@ -102,24 +97,24 @@ utils.defineProperty(JsonRpcProvider.prototype, 'perform', function(method, para
 
         case 'getBalance':
             var blockTag = params.blockTag;
-            if (utils.isHexString(blockTag)) { blockTag = stripHexZeros(blockTag); }
+            if (utils.isHexString(blockTag)) { blockTag = utils.stripHexZeros(blockTag); }
             return this.send('eth_getBalance', [params.address, blockTag]);
 
         case 'getTransactionCount':
             var blockTag = params.blockTag;
-            if (utils.isHexString(blockTag)) { blockTag = stripHexZeros(blockTag); }
+            if (utils.isHexString(blockTag)) { blockTag = utils.stripHexZeros(blockTag); }
             return this.send('eth_getTransactionCount', [params.address, blockTag]);
 
         case 'getCode':
             var blockTag = params.blockTag;
-            if (utils.isHexString(blockTag)) { blockTag = stripHexZeros(blockTag); }
+            if (utils.isHexString(blockTag)) { blockTag = utils.stripHexZeros(blockTag); }
             return this.send('eth_getCode', [params.address, blockTag]);
 
         case 'getStorageAt':
             var position = params.position;
-            if (utils.isHexString(position)) { position = stripHexZeros(position); }
+            if (utils.isHexString(position)) { position = utils.stripHexZeros(position); }
             var blockTag = params.blockTag;
-            if (utils.isHexString(blockTag)) { blockTag = stripHexZeros(blockTag); }
+            if (utils.isHexString(blockTag)) { blockTag = utils.stripHexZeros(blockTag); }
             return this.send('eth_getStorageAt', [params.address, position, blockTag]);
 
         case 'sendTransaction':
@@ -128,7 +123,7 @@ utils.defineProperty(JsonRpcProvider.prototype, 'perform', function(method, para
         case 'getBlock':
             if (params.blockTag) {
                 var blockTag = params.blockTag;
-                if (utils.isHexString(blockTag)) { blockTag = stripHexZeros(blockTag); }
+                if (utils.isHexString(blockTag)) { blockTag = utils.stripHexZeros(blockTag); }
                 return this.send('eth_getBlockByNumber', [blockTag, false]);
             } else if (params.blockHash) {
                 return this.send('eth_getBlockByHash', [params.blockHash, false]);

--- a/providers/provider.js
+++ b/providers/provider.js
@@ -23,6 +23,8 @@ var utils = (function() {
         concat: convert.concat,
         stripZeros: convert.stripZeros,
 
+        stripHexZeros: convert.stripHexZeros,
+
         namehash: require('ethers-utils/namehash'),
 
         toUtf8String: require('ethers-utils/utf8').toUtf8String,
@@ -125,10 +127,10 @@ function checkBlockTag(blockTag) {
     }
 
     if (typeof(blockTag) === 'number') {
-        return utils.hexlify(blockTag);
+        return utils.stripHexZeros(utils.hexlify(blockTag));
     }
 
-    if (utils.isHexString(blockTag)) { return blockTag; }
+    if (utils.isHexString(blockTag)) { return utils.stripHexZeros(blockTag); }
 
     throw new Error('invalid blockTag');
 }

--- a/utils/convert.js
+++ b/utils/convert.js
@@ -157,6 +157,13 @@ function hexlify(value, name) {
     throwError('invalid hexlify value', { name: name, input: value });
 }
 
+function stripHexZeros(value) {
+    while (value.length > 3 && value.substring(0, 3) === '0x0') {
+        value = '0x' + value.substring(3);
+    }
+    return value;
+}
+
 
 module.exports = {
     arrayify: arrayify,
@@ -169,4 +176,6 @@ module.exports = {
 
     hexlify: hexlify,
     isHexString: isHexString,
+
+    stripHexZeros: stripHexZeros,
 };


### PR DESCRIPTION
JSON RPC does not allow(https://github.com/ethereum/wiki/wiki/JSON-RPC#hex-value-encoding) leading hex zeros for quantities(eg: Block Number) which results in the following error.

`
{"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"invalid argument 0: hex number with leading zero digits"}}
`

