### PR TITLE
Do not fail on block difficulties greater than 53 bit numbers

### DIFF
--- a/providers/provider.js
+++ b/providers/provider.js
@@ -6,6 +6,8 @@ var XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;
 
 var networks = require('./networks.json');
 
+var BN = require('bn.js');
+
 var utils = (function() {
     var convert = require('../utils/convert');
     return {
@@ -58,6 +60,15 @@ function allowNull(check, nullValue) {
         if (value == null) { return nullValue; }
         return check(value);
     });
+}
+
+function allowTooBigNumber(check) {
+  return function(value) {
+    if (utils.bigNumberify(value).gte(new BN('0x20000000000000', 'hex'))) {
+      return value;
+    }
+    return check(value);
+  };
 }
 
 function allowFalsish(check, replaceValue) {
@@ -141,7 +152,7 @@ var formatBlock = {
 
     timestamp: checkNumber,
     nonce: allowNull(utils.hexlify),
-    difficulty: allowNull(checkNumber),
+    difficulty: allowNull(allowTooBigNumber(checkNumber)),
 
     gasLimit: utils.bigNumberify,
     gasUsed: utils.bigNumberify,


### PR DESCRIPTION
We are running a Parity PoA network and our block difficulty is `0xfffffffffffffffffffffffffffffff6`. This difficulty is not used since it is not a PoW consensus algorithm.

When connecting a provider, ethers would error out soon after start due to `Number can only safely store up to 53 bits`. The maximum difficulty it can handle is `0x20000000000000` (https://github.com/indutny/bn.js/blob/master/lib/bn.js#L128)

This commit checks the difficulty and if it goes over `0x20000000000000` it keeps it as a string and not a number. Alternatively, I could modify this to keep it as a BN.