### PR TITLE
add confirmations field from transaction response

### DIFF
--- a/providers/provider.js
+++ b/providers/provider.js
@@ -185,6 +185,7 @@ var formatTransaction = {
    blockHash: allowNull(checkHash, null),
    blockNumber: allowNull(checkNumber, null),
    transactionIndex: allowNull(checkNumber, null),
+   confirmations: allowNull(checkNumber, null),
 
    from: utils.getAddress,
 


### PR DESCRIPTION
Provided, at least, by the Etherscan provider.