### PR TITLE
API baseUrl changed

### DIFF
--- a/providers/etherscan-provider.js
+++ b/providers/etherscan-provider.js
@@ -35,13 +35,13 @@ function EtherscanProvider(network, apiKey) {
             baseUrl = 'https://api.etherscan.io';
             break;
         case 'ropsten':
-            baseUrl = 'https://ropsten.etherscan.io';
+            baseUrl = 'https://api-ropsten.etherscan.io';
             break;
         case 'rinkeby':
-            baseUrl = 'https://rinkeby.etherscan.io';
+            baseUrl = 'https://api-rinkeby.etherscan.io';
             break;
         case 'kovan':
-            baseUrl = 'https://kovan.etherscan.io';
+            baseUrl = 'https://api-kovan.etherscan.io';
             break;
         default:
             throw new Error('unsupported network');


### PR DESCRIPTION
Hello, I noticed there is a change in the baseUrl of etherscan APIs

** Important: (Feb-12-2018) The ROPSTEN testnet API service URL has been updated to http://api-ropsten.etherscan.io . The previous API url http://ropsten.etherscan.io will cease to function as of March 31, 2018 

https://ropsten.etherscan.io/apis

same goes for all other testnets

nice work btw :)