### PR TITLE
Fix browser installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To use in a browser:
 
 ```html
 <script charset="utf-8"
-        src="https://cdn.ethers.io/scripts/ethers-v2.min.js"
+        src="https://cdn.ethers.io/scripts/ethers-v3.min.js"
         type="text/javascript">
 </script>
 ```


### PR DESCRIPTION
Browser installation instructions were outdated and pointed to v2, while node's one to v3 (`latest` in npm). I updated the browser's one.