### PR TITLE
Add support for decoding EIP 838 revert reasons

### DIFF
--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -226,3 +226,19 @@ describe('Test Base64 coder', function() {
         assert.equal(utf8.toUtf8String(base64.decode(encoded)), decodedText, 'decodes from base64 sstring');
     });
 });
+
+describe('Test revert reasons decoder', function() {
+    it('throws with a decoded revert reason', function() {
+        var rawData = utils.arrayify('0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002b4c656e677468206d7573742062652067726561746572207468616e206f7220657175616c20746f2032302e000000000000000000000000000000000000000000');
+        var coder = utils.AbiCoder.defaultCoder;
+        var didThrow = false;
+        try {
+            coder.decode(['result'], ['address'], rawData);
+        } catch (e) {
+            didThrow = true;
+            assert.equal(e.message, 'Length must be greater than or equal to 20.');
+        }
+        assert.equal(didThrow, true, 'decode throws an error');
+    });
+});
+

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -5,6 +5,7 @@ var fs = require('fs');
 var path = require('path');
 var zlib = require('zlib');
 
+var AbiCoder = require('../utils/abi-coder');
 var bigNumber = require('../utils/bignumber');
 var convert = require('../utils/convert');
 var keccak256 = require('../utils/keccak256');
@@ -99,6 +100,8 @@ function loadTests(tag) {
 }
 
 module.exports = {
+    AbiCoder: AbiCoder,
+
     randomBytes: randomBytes,
     randomHexString: randomHexString,
     randomNumber:randomNumber,

--- a/utils/abi-coder.js
+++ b/utils/abi-coder.js
@@ -672,6 +672,15 @@ utils.defineProperty(Coder.prototype, 'decode', function(names, types, data) {
 
     data = utils.arrayify(data);
 
+    // If the first four bytes are '08c379a0', it indicates a revert reason. See
+    // EIP 838.
+    if (data && utils.hexlify(data.slice(0, 4)) === '0x08c379a0') {
+        var result = coderTuple(this.coerceFunc, [
+            getParamCoder(this.coerceFunc, 'string', names ? names[0] : undefined),
+        ]).decode(data.slice(4), 0);
+        errors.throwError(result.value.result, errors.REVERT_REASON);
+    }
+
     var coders = [];
     types.forEach(function(type, index) {
         coders.push(getParamCoder(this.coerceFunc, type, (names ? names[index]: undefined)));

--- a/utils/abi-coder.js
+++ b/utils/abi-coder.js
@@ -676,9 +676,9 @@ utils.defineProperty(Coder.prototype, 'decode', function(names, types, data) {
     // EIP 838.
     if (data && utils.hexlify(data.slice(0, 4)) === '0x08c379a0') {
         var result = coderTuple(this.coerceFunc, [
-            getParamCoder(this.coerceFunc, 'string', names ? names[0] : undefined),
+            getParamCoder(this.coerceFunc, 'string', undefined),
         ]).decode(data.slice(4), 0);
-        errors.throwError(result.value.result, errors.REVERT_REASON);
+        errors.throwError(result.value[0], errors.REVERT_REASON);
     }
 
     var coders = [];

--- a/utils/errors.js
+++ b/utils/errors.js
@@ -48,6 +48,8 @@ var codes = { };
     //   - operation
     'UNSUPPORTED_OPERATION',
 
+    // EIP 838 Revert reason
+    'REVERT_REASON',
 
 ].forEach(function(code) {
     defineProperty(codes, code, code);


### PR DESCRIPTION
[EIP 838](https://github.com/ethereum/EIPs/issues/838) introduces revert reasons. Revert reasons have been implemented in Solidity, Geth, Parity, and probably many other projects within the ecosystem. This PR introduces support for decoding them.

For some background, we have a test case in which we expect a contract call to fail. Normally, it returns an address, but in the case of failure it reverts with a reason. Prior to this change, the reason was being parsed as if it were an address, which resulted in an invalid address of all 0's. With this change in place, ethers.js throws with an error message that includes the reason.

Currently, both Geth and Parity (and possibly other implementations) are following the convention of encoding these revert reasons as [`08c379a0` followed by an ABI encoded string](https://github.com/ethereum/EIPs/issues/838#issuecomment-379238333).