### PR TITLE
Add pagination and gasUsed options to EtherscanProvider getHistory

### DIFF
--- a/providers/etherscan-provider.js
+++ b/providers/etherscan-provider.js
@@ -251,21 +251,22 @@ utils.defineProperty(EtherscanProvider.prototype, 'perform', function(method, pa
     return Promise.reject(new Error('not implemented - ' + method));
 });
 
-utils.defineProperty(EtherscanProvider.prototype, 'getHistory', function(addressOrName, startBlock, endBlock) {
+utils.defineProperty(EtherscanProvider.prototype, 'getHistory', function(addressOrName, startBlock, endBlock, pagination) {
 
     var url = this.baseUrl;
 
     var apiKey = '';
     if (this.apiKey) { apiKey += '&apikey=' + this.apiKey; }
 
-    if (startBlock == null) { startBlock = 0; }
-    if (endBlock == null) { endBlock = 99999999; }
+    if (pagination != null || startBlock == null) { startBlock = 0; }
+    if (pagination != null || endBlock == null) { endBlock = 99999999; }
 
     return this.resolveName(addressOrName).then(function(address) {
         url += '/api?module=account&action=txlist&address=' + address;
         url += '&startblock=' + startBlock;
         url += '&endblock=' + endBlock;
-        url += '&sort=asc';
+        url += pagination == null ? '&sort=asc' : '&sort=desc';
+        if (pagination != null) { url += '&page=' + pagination.page + '&offset=' + pagination.offset }
 
         return Provider.fetchJSON(url, null, getResult).then(function(result) {
             var output = [];
@@ -278,6 +279,7 @@ utils.defineProperty(EtherscanProvider.prototype, 'getHistory', function(address
                 }
                 var item = Provider._formatters.checkTransactionResponse(tx);
                 if (tx.timeStamp) { item.timestamp = parseInt(tx.timeStamp); }
+                if (tx.gasUsed) { item.gasUsed = tx.gasUsed }
                 output.push(item);
             });
             return output;
@@ -285,4 +287,4 @@ utils.defineProperty(EtherscanProvider.prototype, 'getHistory', function(address
     });
 });
 
-module.exports = EtherscanProvider;;
+module.exports = EtherscanProvider;

--- a/tests/test-providers.js
+++ b/tests/test-providers.js
@@ -409,7 +409,7 @@ describe('Test extra Etherscan operations', function() {
         this.timeout(100000);
         return provider.getHistory('ricmoo.firefly.eth').then(function(history) {
             assert.ok(history.length > 40, 'Etherscan history returns results');
-            assert.equal(history[0].hash, '0xd25f550cfdff90c086a6496a84dbb2c4577df15b1416e5b3319a3e4ebb5b25d8', 'Etherscan history returns correct transaction');
+            assert.equal(history[0].hash, '0x189f67df9fbdc54dbf03077540e4e4df07a01d0b35c52a7ff816dbbda7c99b74', 'Etherscan history returns correct transaction');
         });
     });
 });


### PR DESCRIPTION
In second commit, I changed verifier in the etherscan history test.

It was 0xd25f550c, and I changed it to 0x189f67df.
It is based on the last mainnet transaction hash of 0xd25f550c sender.

But the current address of 'ricmoo.firefly.eth' is different from 0xd25f550c sender.
I didn't check what network the test code use.