### PR TITLE
Fix redundant provider call when nonce=0 is specified

### DIFF
--- a/contracts/contract.js
+++ b/contracts/contract.js
@@ -177,8 +177,8 @@ function Contract(addressOrName, contractInterface, signerOrProvider) {
                     }
 
                     var noncePromise = null;
-                    if (transaction.nonce) {
-                        noncePromise = Promise.resolve(transaction.nonce)
+                    if (typeof(transaction.nonce) !== 'undefined') {
+                        noncePromise = Promise.resolve(transaction.nonce);
                     } else if (signer.getTransactionCount) {
                         noncePromise = signer.getTransactionCount();
                         if (!(noncePromise instanceof Promise)) {


### PR DESCRIPTION
Hello!

I've noticed a redundant call to providers when `nonce = 0` (as a number) is specified explicitly in contract transactions, for example:

```javascript
await tokenContract.functions.transfer("0x...", "10000000", {
  gasPrice: "1000000000",
  nonce: 0
});
```

Nonce can be `0` when it's the first transaction from the account. In the previous code,

```javascript
                    if (transaction.nonce) {
                        noncePromise = Promise.resolve(transaction.nonce)
                    } else if (signer.getTransactionCount) {
```

It didn't resolve immediately because of `if (0) { ... }` gives false.

Thanks for your work!