### PR TITLE
Adds tokentx route

### DIFF
--- a/providers/etherscan-provider.js
+++ b/providers/etherscan-provider.js
@@ -285,4 +285,39 @@ utils.defineProperty(EtherscanProvider.prototype, 'getHistory', function(address
     });
 });
 
+
+utils.defineProperty(EtherscanProvider.prototype, 'tokentx', function(addressOrName, startBlock, endBlock) {
+
+    var url = this.baseUrl;
+
+    var apiKey = '';
+    if (this.apiKey) { apiKey += '&apikey=' + this.apiKey; }
+
+    if (startBlock == null) { startBlock = 0; }
+    if (endBlock == null) { endBlock = 99999999; }
+
+    return this.resolveName(addressOrName).then(function(address) {
+        url += '/api?module=account&action=tokentx&address=' + address;
+        url += '&startblock=' + startBlock;
+        url += '&endblock=' + endBlock;
+        url += '&sort=asc';
+
+        return Provider.fetchJSON(url, null, getResult).then(function(result) {
+            var output = [];
+            result.forEach(function(tx) {
+                ['contractAddress', 'to'].forEach(function(key) {
+                    if (tx[key] == '') { delete tx[key]; }
+                });
+                if (tx.creates == null && tx.contractAddress != null) {
+                    tx.creates = tx.contractAddress;
+                }
+                var item = Provider._formatters.checkTransactionResponse(tx);
+                if (tx.timeStamp) { item.timestamp = parseInt(tx.timeStamp); }
+                output.push(item);
+            });
+            return output;
+        });
+    });
+});
+
 module.exports = EtherscanProvider;;


### PR DESCRIPTION
This adds a `tokentx` method to the `etherscanProvider`, accompanying the existing `getHistory` method.

This allows the user to query for a list of ERC20 token transfers (in addition to the existing list of ether transfers).