### PR TITLE
JSON.parse RPC response only after receiving all chunks

### DIFF
--- a/providers/ipc-provider.js
+++ b/providers/ipc-provider.js
@@ -51,18 +51,20 @@ var IpcProvider = /** @class */ (function (_super) {
         });
         return new Promise(function (resolve, reject) {
             var stream = net_1.default.connect(_this.path);
+            stream.setEncoding('utf8');
+            var response = '';
             stream.on('data', function (data) {
-                try {
-                    resolve(JSON.parse(data.toString('utf8')).result);
-                    // @TODO: Better pull apart the error
-                    stream.destroy();
-                }
-                catch (error) {
-                    reject(error);
-                    stream.destroy();
-                }
+                response += data;
             });
             stream.on('end', function () {
+                try {
+                    resolve(JSON.parse(response).result);
+                    // @TODO: Better pull apart the error
+                }
+                catch (error) {
+                    error.message += ':\n' + response;
+                    reject(error);
+                }
                 stream.destroy();
             });
             stream.on('error', function (error) {

--- a/src.ts/providers/ipc-provider.ts
+++ b/src.ts/providers/ipc-provider.ts
@@ -41,18 +41,21 @@ export class IpcProvider extends JsonRpcProvider {
 
         return new Promise((resolve, reject) => {
             var stream = net.connect(this.path);
+            stream.setEncoding('utf8');
+            var response = '';
+
             stream.on('data', function(data) {
-                try {
-                    resolve(JSON.parse(data.toString('utf8')).result);
-                    // @TODO: Better pull apart the error
-                    stream.destroy();
-                } catch (error) {
-                    reject(error);
-                    stream.destroy();
-                }
+                response += data;
             });
 
             stream.on('end', function() {
+                try {
+                    resolve(JSON.parse(response).result);
+                    // @TODO: Better pull apart the error
+                } catch (error) {
+                    error.message += ':\n' + response;
+                    reject(error);
+                }
                 stream.destroy();
             });
 

--- a/tests/test-ipc-provider.js
+++ b/tests/test-ipc-provider.js
@@ -6,12 +6,10 @@ var os = require('os');
 var path = require('path');
 var {IpcProvider} = require('../providers/ipc-provider');
 
-const sleep = (ms) => new Promise(res => setTimeout(res, ms, ms));
-
 describe('IpcProvider', () => {
-    describe('.send', () => {
-        var srv
-        var ipcFilename = path.basename(__filename) + '.ipc'
+    describe('#send', () => {
+        var srv;
+        var ipcFilename = path.basename(__filename) + '.ipc';
         var ipcPath = path.join(os.tmpdir(), ipcFilename);
 
         beforeEach(() => srv = net.createServer({allowHalfOpen: true}));
@@ -21,15 +19,17 @@ describe('IpcProvider', () => {
             it('concatenates them before parsing it as JSON', done => {
                 srv.on('connection', socket => {
                     socket.on('data', _data => "throw away");
-                    socket.on('end', async () => {
-                        const [chunk1, chunk2] = [
-                            '{ "result"',
-                            ': {"success": true} }'
+                    socket.on('end', () => {
+                        var [chunk1, chunk2] = [
+                            '{ "result": {"suc',
+                            'cess": true} }'
                         ];
                         socket.write(chunk1);
-                        await sleep(1); // Ensure delivery of chunk1
-                        socket.write(chunk2);
-                        socket.end();
+                        // Ensure delivery of chunk1
+                        setTimeout(() => {
+                            socket.write(chunk2);
+                            socket.end();
+                        }, 10);
                     });
                 });
                 srv.on('error', done);

--- a/tests/test-ipc-provider.js
+++ b/tests/test-ipc-provider.js
@@ -1,0 +1,74 @@
+'use strict';
+
+var assert = require('assert');
+var net = require('net');
+var os = require('os');
+var path = require('path');
+var {IpcProvider} = require('../providers/ipc-provider');
+
+const sleep = (ms) => new Promise(res => setTimeout(res, ms, ms));
+
+describe('IpcProvider', () => {
+    describe('.send', () => {
+        var srv
+        var ipcFilename = path.basename(__filename) + '.ipc'
+        var ipcPath = path.join(os.tmpdir(), ipcFilename);
+
+        beforeEach(() => srv = net.createServer({allowHalfOpen: true}));
+        afterEach(done => srv.listening ? srv.close(done) : done());
+
+        describe('when receives response in chunks', () => {
+            it('concatenates them before parsing it as JSON', done => {
+                srv.on('connection', socket => {
+                    socket.on('data', _data => "throw away");
+                    socket.on('end', async () => {
+                        const [chunk1, chunk2] = [
+                            '{ "result"',
+                            ': {"success": true} }'
+                        ];
+                        socket.write(chunk1);
+                        await sleep(1); // Ensure delivery of chunk1
+                        socket.write(chunk2);
+                        socket.end();
+                    });
+                });
+                srv.on('error', done);
+                srv.listen(ipcPath, () => {
+                    var ipcProvider = new IpcProvider(ipcPath);
+                    ipcProvider.send('<method>', ['<p1>', '<p2>'])
+                        .then(response => {
+                            assert.deepStrictEqual(response, {success: true});
+                            done();
+                        })
+                        .catch(done);
+                });
+            });
+        });
+
+        describe('when receives invalid JSON', () => {
+            it('prints the raw response', done => {
+                const invalidResponse = "{<invalid JSON>}"
+                srv.on('connection', socket => {
+                    socket.on('data', _data => "throw away");
+                    socket.on('end', () => {
+                        socket.write(invalidResponse);
+                        socket.end();
+                    });
+                });
+                srv.on('error', done);
+                srv.listen(ipcPath, () => {
+                    var ipcProvider = new IpcProvider(ipcPath);
+                    ipcProvider.send('<method>', ['<p1>', '<p2>'])
+                        .then(response =>
+                            assert.fail('Unexpected response:\n' + response))
+                        .catch(error => {
+                            assert.strictEqual(error.message,
+                                'Unexpected token < in JSON at position 1:\n'
+                                + invalidResponse)
+                            done()
+                        });
+                });
+            });
+        })
+    });
+});


### PR DESCRIPTION
## Problem

The following error was thrown, when deploying contracts over an `IpcProvider`:

```
        JSON.parse (<anonymous>)
        Socket.<anonymous> (node_modules/ethers/providers/ipc-provider.js:56:34)
```

## Solution

Buffer the RPC server's response chunks and parse them once they all arrive.
The arrival of the complete response is signalled by the RPC server requesting to end the connection.

A slight enhancement was added to the error reporting too, to show the response which couldn't be `JSON.parse`d.