### PR TITLE
Support blockHash in getLogs (EIP-234)

### DIFF
--- a/providers/abstract-provider.d.ts
+++ b/providers/abstract-provider.d.ts
@@ -18,12 +18,18 @@ export interface Block {
     transactions: Array<string>;
 }
 export declare type BlockTag = string | number;
-export declare type Filter = {
+export declare type FilterByBlockHash = {
+    blockHash: string;
+    address?: string;
+    topics?: Array<string | Array<string>>;
+};
+export declare type FilterByBlockRange = {
     fromBlock?: BlockTag;
     toBlock?: BlockTag;
     address?: string;
     topics?: Array<string | Array<string>>;
 };
+export declare type Filter = FilterByBlockHash | FilterByBlockRange;
 export interface Log {
     blockNumber?: number;
     blockHash?: string;

--- a/providers/base-provider.js
+++ b/providers/base-provider.js
@@ -321,6 +321,7 @@ function checkTopics(topics) {
     return topics;
 }
 var formatFilter = {
+    blockHash: allowNull(checkHash, undefined),
     fromBlock: allowNull(checkBlockTag, undefined),
     toBlock: allowNull(checkBlockTag, undefined),
     address: allowNull(address_1.getAddress, undefined),

--- a/src.ts/providers/abstract-provider.ts
+++ b/src.ts/providers/abstract-provider.ts
@@ -34,12 +34,20 @@ export interface Block {
 
 export type BlockTag = string | number;
 
-export type Filter = {
+export type FilterByBlockHash = {
+    blockHash: string;
+    address?: string,
+    topics?: Array<string | Array<string>>,
+}
+
+export type FilterByBlockRange = {
     fromBlock?: BlockTag,
     toBlock?: BlockTag,
     address?: string,
     topics?: Array<string | Array<string>>,
 }
+
+export type Filter = FilterByBlockHash | FilterByBlockRange;
 
 export interface Log {
     blockNumber?: number;

--- a/src.ts/providers/base-provider.ts
+++ b/src.ts/providers/base-provider.ts
@@ -360,6 +360,7 @@ function checkTopics(topics: any): any {
 }
 
 const formatFilter = {
+    blockHash: allowNull(checkHash, undefined),
     fromBlock: allowNull(checkBlockTag, undefined),
     toBlock: allowNull(checkBlockTag, undefined),
     address: allowNull(getAddress, undefined),


### PR DESCRIPTION
Simple change to allow blockHash through `checkFilter()`. The type union isn't strictly necessary, but it is more descriptive.