### PR TITLE
Fully deprecate v1 Infura API

### DIFF
--- a/src.ts/providers/infura-provider.ts
+++ b/src.ts/providers/infura-provider.ts
@@ -53,9 +53,9 @@ export class InfuraProvider extends JsonRpcProvider {
 
         // Legacy API Access Token
         } else {
-            super('https://' + host + '/' + projectId, standard);
-            defineReadOnly(this, 'apiAccessToken', projectId);
-            defineReadOnly(this, 'projectId', null);
+            errors.throwError(
+                'Legacy INFURA API is deprecated. Please create use the new Project ID', 
+                errors.INVALID_ARGUMENT, { accessToken: projectId });
         }
 
         errors.checkNew(this, InfuraProvider);


### PR DESCRIPTION
As of March 27, Infura is going to be deprecating the old style API access. All requests will be stopped with the legacy endpoint. Consider fully deprecating and issuing a friendly error message that a new style projectId needs to be used.