### PR TITLE
fix Promise check fail problem.

### DIFF
--- a/providers/base-provider.js
+++ b/providers/base-provider.js
@@ -421,7 +421,7 @@ var BaseProvider = /** @class */ (function (_super) {
     function BaseProvider(network) {
         var _this = _super.call(this) || this;
         errors.checkNew(_this, abstract_provider_1.Provider);
-        if (network instanceof Promise) {
+        if (properties_1.isPromise(network)) {
             properties_1.defineReadOnly(_this, 'ready', network.then(function (network) {
                 properties_1.defineReadOnly(_this, '_network', network);
                 return network;
@@ -1034,7 +1034,7 @@ var BaseProvider = /** @class */ (function (_super) {
     BaseProvider.prototype.resolveName = function (name) {
         var _this = this;
         // If it is a promise, resolve it then recurse
-        if (name instanceof Promise) {
+        if (properties_1.isPromise(name)) {
             return name.then(function (addressOrName) {
                 return _this.resolveName(addressOrName);
             });
@@ -1069,7 +1069,7 @@ var BaseProvider = /** @class */ (function (_super) {
     };
     BaseProvider.prototype.lookupAddress = function (address) {
         var _this = this;
-        if (address instanceof Promise) {
+        if (properties_1.isPromise(address)) {
             return address.then(function (address) {
                 return _this.lookupAddress(address);
             });

--- a/src.ts/providers/base-provider.ts
+++ b/src.ts/providers/base-provider.ts
@@ -6,7 +6,7 @@ import { hexDataLength, hexDataSlice, hexlify, hexStripZeros, isHexString, strip
 import { AddressZero } from "../constants";
 import { namehash } from '../utils/hash';
 import { getNetwork } from '../utils/networks';
-import { defineReadOnly, inheritable, resolveProperties, shallowCopy } from '../utils/properties';
+import { defineReadOnly, inheritable, isPromise, resolveProperties, shallowCopy } from '../utils/properties';
 import { encode as rlpEncode } from '../utils/rlp';
 import { parse as parseTransaction } from '../utils/transaction';
 import { toUtf8String } from '../utils/utf8';
@@ -536,7 +536,7 @@ export class BaseProvider extends Provider {
         super();
         errors.checkNew(this, Provider);
 
-        if (network instanceof Promise) {
+        if (isPromise(network)) {
             defineReadOnly(this, 'ready', network.then((network) => {
                 defineReadOnly(this, '_network', network);
                 return network;
@@ -1165,7 +1165,7 @@ export class BaseProvider extends Provider {
     resolveName(name: string | Promise<string>): Promise<string> {
 
         // If it is a promise, resolve it then recurse
-        if (name instanceof Promise) {
+        if (isPromise(name)) {
             return name.then((addressOrName) => {
                 return this.resolveName(addressOrName);
             });
@@ -1199,7 +1199,7 @@ export class BaseProvider extends Provider {
     }
 
     lookupAddress(address: string | Promise<string>): Promise<string> {
-        if (address instanceof Promise) {
+        if (isPromise(address)) {
             return address.then((address) => {
                 return this.lookupAddress(address);
             });

--- a/src.ts/utils/properties.ts
+++ b/src.ts/utils/properties.ts
@@ -21,13 +21,17 @@ export function isType(object: any, type: string): boolean {
     return (object && object._ethersType === type);
 }
 
+export function isPromise(object: any): boolean {
+    return object && typeof object.then === 'function';
+}
+
 export function resolveProperties(object: any): Promise<any> {
     let result: any = {};
 
     let promises: Array<Promise<void>> = [];
     Object.keys(object).forEach((key) => {
         let value = object[key];
-        if (value instanceof Promise) {
+        if (isPromise(value)) {
             promises.push(
                 value.then((value) => {
                     result[key] = value;

--- a/utils/properties.d.ts
+++ b/utils/properties.d.ts
@@ -1,6 +1,7 @@
 export declare function defineReadOnly(object: any, name: string, value: any): void;
 export declare function setType(object: any, type: string): void;
 export declare function isType(object: any, type: string): boolean;
+export declare function isPromise(object: any): boolean;
 export declare function resolveProperties(object: any): Promise<any>;
 export declare function checkProperties(object: any, properties: {
     [name: string]: boolean;

--- a/utils/properties.js
+++ b/utils/properties.js
@@ -26,12 +26,16 @@ function isType(object, type) {
     return (object && object._ethersType === type);
 }
 exports.isType = isType;
+function isPromise(object) {
+    return (object && typeof object.then === 'function');
+}
+exports.isPromise = isPromise;
 function resolveProperties(object) {
     var result = {};
     var promises = [];
     Object.keys(object).forEach(function (key) {
         var value = object[key];
-        if (value instanceof Promise) {
+        if (isPromise(value)) {
             promises.push(value.then(function (value) {
                 result[key] = value;
                 return null;


### PR DESCRIPTION
This pull request is to fix the Promise check failure.

Checking Promise instance with the 'instanceof' expression could fail,
even though the object is instance of Promise. (when  the object is made on different namespace.)

Ex)
if (object instanceof Promise) {
  // code could not come here if the object is instance of Promise created on different namespace
}

So I suggest to use then function check instead of using instanceof keyword.
Checking then function is safe to check promise. 
Why don't you check following stackoverflow thread.
https://stackoverflow.com/questions/27746304/how-do-i-tell-if-an-object-is-a-promise

HOW-TO-REPRODUCE
I've encountered the error when I use ethers.js library along with createNamespace function of 'continuation-local-storage' package.

const createNamespace = require('continuation-local-storage').createNamespace;
const session = createNamespace('my session');  // if I use this function.

// And then I use ethers.js method like this.
const contractFactory = new ethers.ContractFactory(...)
await contractFactory.deploy(...)

// Then boom! The following error occur!

(node:67717) UnhandledPromiseRejectionWarning: Error: invalid BigNumber value (arg="value", value={}, version=4.0.33)
    at Object.throwError (/Users/kimilhee/Documents/sa_ws/dex-server/node_modules/ethers/errors.js:76:17)
    at new BigNumber (/Users/kimilhee/Documents/sa_ws/dex-server/node_modules/ethers/utils/bignumber.js:99:20)
    at bigNumberify (/Users/kimilhee/Documents/sa_ws/dex-server/node_modules/ethers/utils/bignumber.js:182:12)
    at Object.gasPrice (/Users/kimilhee/Documents/sa_ws/dex-server/node_modules/ethers/providers/base-provider.js:60:16)
    at check (/Users/kimilhee/Documents/sa_ws/dex-server/node_modules/ethers/providers/base-provider.js:42:36)
    at checkTransactionRequest (/Users/kimilhee/Documents/sa_ws/dex-server/node_modules/ethers/providers/base-provider.js:267:12)
    at /Users/kimilhee/Documents/sa_ws/dex-server/node_modules/ethers/providers/base-provider.js:838:49
    at propagateAslWrapper (/Users/kimilhee/Documents/sa_ws/dex-server/node_modules/async-listener/index.js:504:23)
    at /Users/kimilhee/Documents/sa_ws/dex-server/node_modules/async-listener/glue.js:188:31
    at /Users/kimilhee/Documents/sa_ws/dex-server/node_modules/async-listener/index.js:541:70
    at /Users/kimilhee/Documents/sa_ws/dex-server/node_modules/async-listener/glue.js:188:31
(node:67717) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:67717) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:67717) UnhandledPromiseRejectionWarning: Error: invalid hexlify value (arg="value", value={}, version=4.0.33)
    at Object.throwError (/Users/kimilhee/Documents/sa_ws/dex-server/node_modules/ethers/errors.js:76:17)
    at Object.hexlify (/Users/kimilhee/Documents/sa_ws/dex-server/node_modules/ethers/utils/bytes.js:180:12)
    at /Users/kimilhee/Documents/sa_ws/dex-server/node_modules/ethers/utils/transaction.js:49:42
    at Array.forEach (<anonymous>)
    at Object.serialize (/Users/kimilhee/Documents/sa_ws/dex-server/node_modules/ethers/utils/transaction.js:47:23)
    at /Users/kimilhee/Documents/sa_ws/dex-server/node_modules/ethers/wallet.js:84:39
    at propagateAslWrapper (/Users/kimilhee/Documents/sa_ws/dex-server/node_modules/async-listener/index.js:504:23)
    at /Users/kimilhee/Documents/sa_ws/dex-server/node_modules/async-listener/glue.js:188:31
    at /Users/kimilhee/Documents/sa_ws/dex-server/node_modules/async-listener/index.js:541:70
    at /Users/kimilhee/Documents/sa_ws/dex-server/node_modules/async-listener/glue.js:188:31
(node:67717) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
^C