### PR TITLE
Fix error message: "does not support ENS"

### DIFF
--- a/src.ts/providers/base-provider.ts
+++ b/src.ts/providers/base-provider.ts
@@ -1142,7 +1142,7 @@ export class BaseProvider extends Provider {
             // No ENS...
             if (!network.ensAddress) {
                 errors.throwError(
-                    'network does support ENS',
+                    'network does not support ENS',
                     errors.UNSUPPORTED_OPERATION,
                     { operation: 'ENS', network: network.name }
                 );


### PR DESCRIPTION
A minor typo fix. Otherwise, the error message is confusing when it says "Error: network does support ENS".