### PR TITLE
Rate limit retry provider for Infura

### DIFF
--- a/packages/experimental/README.md
+++ b/packages/experimental/README.md
@@ -49,7 +49,7 @@ BrainWallet.generate(username, password, showProgess).then((wallet) => {
 **NonceManager**
 
 ```javascript
-import { NonceManager } from "@ethersproject/experimenatl/nonce-manager";
+import { NonceManager } from "@ethersproject/experimental/nonce-manager";
 
 let signer = "... any way you get a signer ...";
 
@@ -64,7 +64,7 @@ let managedSigner = new NonceManager(signer);
 **RetryProvider**
 
 ```javascript
-import { RetryProvider } from "@ethersproject/experimenatl/retry-provider";
+import { RetryProvider } from "@ethersproject/experimental/retry-provider";
 
 let provider = "... any way you get a signer...";
 
@@ -72,7 +72,7 @@ let provider = "... any way you get a signer...";
 let options = {
 }
 
-let retryProivder = new RetryProvider(provider, options);
+let retryProvider = new RetryProvider(provider, options);
 ```
 
 

--- a/packages/providers/src.ts/index.ts
+++ b/packages/providers/src.ts/index.ts
@@ -23,7 +23,7 @@ import { CloudflareProvider } from "./cloudflare-provider";
 import { EtherscanProvider } from "./etherscan-provider";
 import { FallbackProvider } from "./fallback-provider";
 import { IpcProvider } from "./ipc-provider";
-import { InfuraProvider } from "./infura-provider";
+import { InfuraProvider, InfuraRetryProvider } from "./infura-provider";
 import { JsonRpcProvider, JsonRpcSigner } from "./json-rpc-provider";
 import { NodesmithProvider } from "./nodesmith-provider";
 import { Web3Provider } from "./web3-provider";
@@ -51,6 +51,7 @@ export {
     CloudflareProvider,
     EtherscanProvider,
     InfuraProvider,
+    InfuraRetryProvider,
     JsonRpcProvider,
     NodesmithProvider,
     Web3Provider,

--- a/packages/providers/src.ts/infura-provider.ts
+++ b/packages/providers/src.ts/infura-provider.ts
@@ -4,10 +4,10 @@ import { Network } from "@ethersproject/networks";
 
 import { Logger } from "@ethersproject/logger";
 import { version } from "./_version";
+
 const logger = new Logger(version);
 
 import { UrlJsonRpcProvider } from "./url-json-rpc-provider";
-
 
 const defaultProjectId = "84842078b09946638c03157f83405213"
 
@@ -45,5 +45,43 @@ export class InfuraProvider extends UrlJsonRpcProvider {
         }
 
         return "https:/" + "/" + host + "/v3/" + apiKey;
+    }
+}
+
+export class InfuraRetryProvider extends InfuraProvider {
+    pause(ms:number): Promise<any> {
+        return new Promise((res) => setTimeout(res, ms));
+    }
+
+    perform(method: string, params: any): Promise<any> {
+        const MAX_RETRY:number = 3;
+        let rateLimited:boolean = false;
+        let rate:number = 0;
+        let retries: number = 0;
+
+        return new Promise(async (resolve, reject) => {
+            do {
+                await this.pause(rate);
+                try {
+                    const result = await super.perform(method, params);
+                    rateLimited = false;
+                    resolve(result);
+                } catch(e) {
+                    const errors = JSON.parse(e.body);
+
+                    if (e.status === 429) {
+                        if(retries++ === MAX_RETRY) {
+                            reject(e);
+                            rateLimited = false;
+                            return;
+                        };
+                        rateLimited = true;
+                        rate = errors.error.data.rate.backoff_seconds * 1000;
+                    } else {
+                        throw e;
+                    }
+                }
+            } while(rateLimited);
+        })
     }
 }

--- a/packages/providers/src.ts/infura-provider.ts
+++ b/packages/providers/src.ts/infura-provider.ts
@@ -59,6 +59,15 @@ export class InfuraProvider extends UrlJsonRpcProvider {
     }
 }
 
+/**
+ * This provider is assuming that the JsonRPC provider
+ * up the inheritance hierarchy is http based. This will
+ * not work for wss based connections.
+ * InfuraRateLimitError.code = -32005 may also work.
+ * This code may also be ambiguous with data limits as well, so
+ * care should be taken when relying on the status code.
+ * @See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md
+ */
 export class InfuraRetryProvider extends InfuraProvider {
     pause(ms:number): Promise<any> {
         return new Promise((res) => setTimeout(res, ms));


### PR DESCRIPTION
This adds a retryable provider for Infura's rate limit. If the direction looks good, I'd like to actually merge this with the main InfuraProvider before merging it into the main line.  I think there should just be 1 Infura provider to reduce confusion.

The main impulse for the changes here instead of relying on the experimental RetryProvider or using the polling mechanism is that the wait time is dynamic based on the return payload from Infura:
```
{
  "jsonrpc": "2.0",
  "id": 1,
  "error": {
    "code": -32005,
    "message": "project ID request rate exceeded",
    "data": {
      "see": "https://infura.io/docs/ethereum/jsonrpc/ratelimits",
      "current_rps": 13.333,
      "allowed_rps": 10.0,
      "backoff_seconds": 30.0,
    }
  }
}
```