### PR TITLE
Fix CoderNumber.encode( BN )

### DIFF
--- a/src.ts/utils/bignumber.ts
+++ b/src.ts/utils/bignumber.ts
@@ -85,6 +85,9 @@ export class BigNumber implements Hexable {
         } else if (value instanceof BigNumber) {
             defineReadOnly(this, '_hex', value._hex);
 
+        } else if (BN.BN.isBN(value)) {
+            defineReadOnly(this, '_hex', toHex(value));
+            
         } else if ((<any>value).toHexString) {
             defineReadOnly(this, '_hex', toHex(toBN((<any>value).toHexString())));
 

--- a/thirdparty.d.ts
+++ b/thirdparty.d.ts
@@ -23,6 +23,8 @@ declare module "aes-js" {
 
 declare module "bn.js" {
     export class BN {
+        static isBN(value: any): value is BN;
+        
         constructor(value: string | number, radix?: number);
 
         add(other: BN): BN;


### PR DESCRIPTION
Adds a check for `BN.isBN` in `BigNumber.constructor`

Closes #653 