### PR TITLE
Move @types/node to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "version": "npm dist"
   },
   "dependencies": {
-    "@types/node": "^10.3.2",
     "aes-js": "3.0.0",
     "bn.js": "^4.4.0",
     "elliptic": "6.3.3",
@@ -31,6 +30,7 @@
     "xmlhttprequest": "1.8.0"
   },
   "devDependencies": {
+    "@types/node": "^10.3.2",
     "browserify": "^16.2.3",
     "browserify-zlib": "^0.2.0",
     "dts-bundle": "^0.7.3",


### PR DESCRIPTION
`@types` dependencies are only to facilitate typescript development and they are not required when one just using a library.