### PR TITLE
Allow arbitrary property access on event arguments

### DIFF
--- a/src.ts/contract.ts
+++ b/src.ts/contract.ts
@@ -39,9 +39,20 @@ export type EventFilter = {
     //topics?: Array<string | Array<string>>
 };
 
+/**
+ * We add a index signature to Array<any> here
+ * since we dynamically add argument properties in the array
+ * that can be accessed via either the dot notation (e.args.foo)
+ * or
+ * that can be accessed via the array index notation (e.args['foo'])
+ */
+interface EventArgs extends Array<any> {
+    [argKey: string]: any
+}
+
 // The (n + 1)th parameter passed to contract event callbacks
 export interface Event extends Log {
-    args?: Array<any>;
+    args?: EventArgs;
     decode?: (data: string, topics?: Array<string>) => any;
     event?: string;
     eventSignature?: string;


### PR DESCRIPTION
The current typing for `Event['args']` does not allow for us to use the added properties, since typescript will error out and say that the property does not exist on the type of Array<any>.

For example, let's say that we have the event with the arguments `foo` and `bar`.

```ts
const tx = await myContractInstance.myMethod()

// gives us an event of { 0: '0xDEAD', 1: '0xBEEF', foo: '0xDEAD', bar: '0xBEEF' }
const receipt = await tx.wait()

// works
receipt.events.args[0] // 0xDEAD

// does not work, property does not exist on type Array<any>
receipt.events.args.foo // 0xDEAD
```
This PR fixes that, so that we can access arbitrary properties on our `args` arrayish-object.