### PR TITLE
Switch from indutny/elliptic to noble-secp256k1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "elliptic": "6.5.4",
     "hash.js": "1.1.7",
     "js-sha3": "0.5.7",
+    "noble-secp256k1": "^1.2.8",
     "scrypt-js": "3.0.1",
     "solc": "0.7.1",
     "tiny-inflate": "1.0.3",

--- a/packages/signing-key/package.json
+++ b/packages/signing-key/package.json
@@ -9,7 +9,8 @@
     "@ethersproject/properties": "^5.4.0",
     "bn.js": "^4.11.9",
     "elliptic": "6.5.4",
-    "hash.js": "1.1.7"
+    "hash.js": "1.1.7",
+    "noble-secp256k1": "^1.2.8"
   },
   "description": "Elliptic curve library functions for the secp256k1 curve.",
   "ethereum": "donations.ethers.eth",

--- a/packages/signing-key/package.json
+++ b/packages/signing-key/package.json
@@ -7,6 +7,7 @@
     "@ethersproject/bytes": "^5.4.0",
     "@ethersproject/logger": "^5.4.0",
     "@ethersproject/properties": "^5.4.0",
+    "@ethersproject/sha2": "^5.4.0",
     "bn.js": "^4.11.9",
     "elliptic": "6.5.4",
     "hash.js": "1.1.7",

--- a/packages/signing-key/src.ts/index.ts
+++ b/packages/signing-key/src.ts/index.ts
@@ -1,11 +1,17 @@
 "use strict";
 import * as secp256k1 from "noble-secp256k1";
+import { computeHmac, SupportedAlgorithm } from "@ethersproject/sha2";
 import { arrayify, BytesLike, hexlify, hexZeroPad, Signature, SignatureLike, splitSignature } from "@ethersproject/bytes";
 import { defineReadOnly } from "@ethersproject/properties";
 
 import { Logger } from "@ethersproject/logger";
 import { version } from "./_version";
 const logger = new Logger(version);
+
+// @ts-ignore
+secp256k1.utils.hmacSha256 = function(key: Uint8Array, ...messages: Uint8Array[]): Uint8Array {
+    return arrayify(computeHmac(SupportedAlgorithm.sha256, key, Buffer.concat(messages)));
+}
 
 export class SigningKey {
     readonly curve: string;


### PR DESCRIPTION
I've been developing a highly auditable self-contained zero-dependency secp256k1 library @ https://github.com/paulmillr/noble-secp256k1 & https://paulmillr.com/posts/noble-secp256k1-fast-ecc/

The PR should also resolve #666, since noble-secp256k1 is algorithmically protected against timing attack.

The library will increase security of ethers, since all Noble releases are signed, don't contain dependencies and a user is able to verify the source code in a simpler way versus indutny/elliptic, which uses BigNum library with thousands of LOC.

It also has very simple API and is fun to play with.

A hacker could break into any dependency of elliptic and steal important user data. This has happened before:

- https://medium.com/intrinsic/compromised-npm-package-event-stream-d47d08605502
- https://blog.npmjs.org/post/185397814280/plot-to-steal-cryptocurrency-foiled-by-the-npm