### PR TITLE
fix: support strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ docs/build/doctrees/
 docs/build/html/_sources/
 dist/types/shims/
 shims/*.d.ts
+.vscode

--- a/src.ts/utils/units.ts
+++ b/src.ts/utils/units.ts
@@ -52,9 +52,10 @@ function getUnitInfo(name: string | number): UnitInfo {
     // Try the cache
     let info = unitInfos[String(name).toLowerCase()];
 
-    if (!info && typeof(name) === 'number' && parseInt(String(name)) == name && name >= 0 && name <= 256) {
+    const castedName = parseInt(String(name))
+    if (!info && castedName == name && castedName >= 0 && castedName <= 256) {
         let value = '1';
-        for (let i = 0; i < name; i++) { value += '0'; }
+        for (let i = 0; i < castedName; i++) { value += '0'; }
         info = _getUnitInfo(value);
     }
 

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -365,3 +365,36 @@ describe("Hexlify", function() {
         });
     });
 });
+
+describe.only("getUnitInfo", function() {
+    it("Get unit info by cache", function() {
+        ['gwei', 'ether'].forEach(function(name, index) {
+            const expected = 1000000000 ** (1 - index)
+            assert.equal(ethers.utils.formatUnits('1000000000000000000', name), expected.toFixed(1), "formatUnits with names");
+        });
+
+        ['9', '18'].forEach(function(name, index) {
+            const expected = 1000000000 ** (1 - index)
+            assert.equal(ethers.utils.formatUnits('1000000000000000000', name), expected.toFixed(1), "formatUnits with names");
+        });
+
+        [9, 18].forEach(function(name, index) {
+            const expected = 1000000000 ** (1 - index)
+            assert.equal(ethers.utils.formatUnits('1000000000000000000', name), expected.toFixed(1), "formatUnits with names");
+        });
+    });
+
+    it("Get unit info by strings", function() {
+        ['7', '14'].forEach(function(name, index) {
+            const expected = 1000000000000000000 / 10000000 ** (index + 1)
+            assert.equal(ethers.utils.formatUnits('1000000000000000000', name), expected.toFixed(1), "formatUnits with string");
+        });
+    });
+
+    it("Get unit info by numbers", function() {
+        [7, 14].forEach(function(name, index) {
+            const expected = 1000000000000000000 / 10000000 ** (index + 1)
+            assert.equal(ethers.utils.formatUnits('1000000000000000000', name), expected.toFixed(1), "formatUnits with number");
+        });
+    });
+});

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -366,7 +366,7 @@ describe("Hexlify", function() {
     });
 });
 
-describe.only("getUnitInfo", function() {
+describe("getUnitInfo", function() {
     it("Get unit info by cache", function() {
         ['gwei', 'ether'].forEach(function(name, index) {
             const expected = 1000000000 ** (1 - index)

--- a/utils/units.js
+++ b/utils/units.js
@@ -40,9 +40,10 @@ function _getUnitInfo(value) {
 function getUnitInfo(name) {
     // Try the cache
     var info = unitInfos[String(name).toLowerCase()];
-    if (!info && typeof (name) === 'number' && parseInt(String(name)) == name && name >= 0 && name <= 256) {
+    var castedName = parseInt(String(name));
+    if (!info && castedName == name && castedName >= 0 && castedName <= 256) {
         var value = '1';
-        for (var i = 0; i < name; i++) {
+        for (var i = 0; i < castedName; i++) {
             value += '0';
         }
         info = _getUnitInfo(value);


### PR DESCRIPTION
Hi!

I've added support for string numbers as `"2"`, `"7"`, etc which are not part of the cache when calling `formatUnits`.

Right now, if you are manipulating strings and call `formatUnit('2')` it will throw.