### PR TITLE
Expose shln and shrn Bit operations

### DIFF
--- a/src.ts/utils/bignumber.ts
+++ b/src.ts/utils/bignumber.ts
@@ -165,6 +165,14 @@ export class BigNumber implements Hexable {
     gte(other: BigNumberish): boolean {
         return _bnify(this).gte(toBN(other));
     }
+    
+    shln(other: BigNumberish): boolean {
+        return _bnify(this).shln(toBN(other));
+    }
+
+    shrn(other: BigNumberish): boolean {
+        return _bnify(this).shrn(toBN(other));
+    }
 
     isZero(): boolean {
         return _bnify(this).isZero();


### PR DESCRIPTION
Would be nice to expose these as they are commonly used for merkle verification and construction.

Perhaps exposing all Bit Operations that BN.js supports would be ideal.