### PR TITLE
Fix error in getLogs method

### DIFF
--- a/packages/providers/src.ts/base-provider.ts
+++ b/packages/providers/src.ts/base-provider.ts
@@ -59,9 +59,10 @@ function serializeTopics(topics: Array<string | Array<string>>): string {
 function deserializeTopics(data: string): Array<string | Array<string>> {
     if (data === "") { return [ ]; }
     return data.split(/&/g).map((topic) => {
-        return topic.split("|").map((topic) => {
+        const comps = topic.split("|").map((topic) => {
             return ((topic === "null") ? null: topic);
         });
+        return comps.length === 1 ? comps[0] : comps;
     });
 }
 


### PR DESCRIPTION
When listening on an event filter with a null parameter followed by
a non-null parameter, it would keep throwing the error:

`{ code: -32600, message: "data types must start with 0x" }`

Turns out params.topics were being encoded as e.g.:
```
  "topics": [
    ["0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b"],
    [null],
    [
      "0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b",
      "0x0000000000000000000000000aff3454fce5edbc8cca8697c15331677e6ebccc"
    ]
  ]
```
instead of:
```
  "topics": [
    "0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b",
    null,
    [
      "0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b",
      "0x0000000000000000000000000aff3454fce5edbc8cca8697c15331677e6ebccc"
    ]
  ]
```
Fix this by flattening the array if there is only one topic in a
position.