### PR TITLE
Fix WebSocket Provider Block Subscription

### DIFF
--- a/packages/providers/src.ts/websocket-provider.ts
+++ b/packages/providers/src.ts/websocket-provider.ts
@@ -179,7 +179,7 @@ export class WebSocketProvider extends JsonRpcProvider {
     _startEvent(event: Event): void {
         switch (event.type) {
             case "block":
-                this._subscribe("block", [ "newHeads", { } ], (result: any) => {
+                this._subscribe("block", [ "newHeads" ], (result: any) => {
                     this.emit("block", BigNumber.from(result.number).toNumber());
                 });
                 break;


### PR DESCRIPTION
This PR removes the second argument, an empty object, from the block header subscription call in the WebSocket provider.

Both Geth and Parity throw due to the presence of a second argument. There was a time when Geth expected an empty object to be passed, but this has [since been removed](https://github.com/ethereum/go-ethereum/pull/16454) to keep compatibility with Parity.

Geth Error: `Error: too many arguments, want at most 1`

Parity Error: `Couldn't parse parameters: newHeads`