### PR TITLE
Fix 'TypeError: this is undefined'

### DIFF
--- a/packages/contracts/src.ts/index.ts
+++ b/packages/contracts/src.ts/index.ts
@@ -202,7 +202,7 @@ async function populateCallTransaction(contract: Contract, fragment: FunctionFra
     delete overrides.from;
 
     const tx = await populateTransaction(contract, fragment, args, overrides);
-    if (ro.from) { (<any>tx).from = this.interface.constructor.getAddress(ro.from); }
+    if (ro.from) { (<any>tx).from = (<any>(contract.interface.constructor)).getAddress(ro.from); }
 
     return tx;
 }


### PR DESCRIPTION
Because `populateCallTransaction` is not called as a method, this line of code was throwing `TypeError: this is undefined` at runtime for me in the browser. I still don't understand why my tests are passing though...

Any ideas? Is this a valid fix?

UPDATE: hmm, could be that during tests the `from` override is never set.