### PR TITLE
Remove unused dependency in bignumber

### DIFF
--- a/packages/bignumber/package.json
+++ b/packages/bignumber/package.json
@@ -3,7 +3,6 @@
   "dependencies": {
     "@ethersproject/bytes": "^5.0.0",
     "@ethersproject/logger": "^5.0.0",
-    "@ethersproject/properties": "^5.0.0",
     "bn.js": "^4.4.0"
   },
   "description": "BigNumber library used in ethers.js.",


### PR DESCRIPTION
`@ethersproject/properties` doesn't seem to be used in `@ethersproject/bignumber`, no reason to declare it as a dependency.