### PR TITLE
Fix docs typo for Contract Factory argument type

### DIFF
--- a/docs/v5/api/contract/contract-factory/README.md
+++ b/docs/v5/api/contract/contract-factory/README.md
@@ -10,7 +10,7 @@ ContractFactory
 Creating Instances
 ------------------
 
-#### **new ***ethers* . **ContractFactory**( interface , bydecode [ , signer ] )
+#### **new ***ethers* . **ContractFactory**( interface , bytecode [ , signer ] )
 
 
 


### PR DESCRIPTION
Fix bydecode to bytecode.

https://docs.ethers.io/v5/api/contract/contract-factory/#ContractFactory--creating