### PR TITLE
Add the ability to get transaction histories for ERC20 tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "ethers",
   "private": true,
+  "version": "1.0.0",
   "repository": {
     "type": "git",
-    "url": "git://github.com/ethers-io/ethers.js.git"
+    "url": "git://github.com/michaeltout/ethers.js.git"
   },
   "scripts": {
     "postinstall": "npm run bootstrap",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "ethers",
   "private": true,
-  "version": "1.0.0",
   "repository": {
     "type": "git",
-    "url": "git://github.com/michaeltout/ethers.js.git"
+    "url": "git://github.com/ethers-io/ethers.js.git"
   },
   "scripts": {
     "postinstall": "npm run bootstrap",

--- a/packages/providers/lib/etherscan-provider.d.ts
+++ b/packages/providers/lib/etherscan-provider.d.ts
@@ -7,5 +7,5 @@ export declare class EtherscanProvider extends BaseProvider {
     constructor(network?: Networkish, apiKey?: string);
     detectNetwork(): Promise<Network>;
     perform(method: string, params: any): Promise<any>;
-    getHistory(addressOrName: string | Promise<string>, startBlock?: BlockTag, endBlock?: BlockTag): Promise<Array<TransactionResponse>>;
+    getHistory(addressOrName: string | Promise<string>, startBlock?: BlockTag, endBlock?: BlockTag, contractAddress?: string): Promise<Array<TransactionResponse>>;
 }

--- a/packages/providers/lib/etherscan-provider.js
+++ b/packages/providers/lib/etherscan-provider.js
@@ -229,6 +229,7 @@ var EtherscanProvider = /** @class */ (function (_super) {
                             case "estimateGas": return [3 /*break*/, 12];
                             case "getLogs": return [3 /*break*/, 13];
                             case "getEtherPrice": return [3 /*break*/, 20];
+                            case "getabi": return [3 /*break*/, 24];
                         }
                         return [3 /*break*/, 22];
                     case 1:
@@ -385,6 +386,10 @@ var EtherscanProvider = /** @class */ (function (_super) {
                     case 21: return [2 /*return*/, _b.apply(void 0, [(_c.sent()).ethusd])];
                     case 22: return [3 /*break*/, 23];
                     case 23: return [2 /*return*/, _super.prototype.perform.call(this, method, params)];
+                    case 24:
+                        url += "/api?module=contract&action=getabi&address=" + params.address;
+                        url += apiKey;
+                        return [2 /*return*/, get(url, getResult)];
                 }
             });
         });

--- a/packages/providers/lib/etherscan-provider.js
+++ b/packages/providers/lib/etherscan-provider.js
@@ -390,7 +390,7 @@ var EtherscanProvider = /** @class */ (function (_super) {
         });
     };
     // @TODO: Allow startBlock and endBlock to be Promises
-    EtherscanProvider.prototype.getHistory = function (addressOrName, startBlock, endBlock) {
+    EtherscanProvider.prototype.getHistory = function (addressOrName, startBlock, endBlock, contractAddress) {
         var _this = this;
         var url = this.baseUrl;
         var apiKey = "";
@@ -404,10 +404,11 @@ var EtherscanProvider = /** @class */ (function (_super) {
             endBlock = 99999999;
         }
         return this.resolveName(addressOrName).then(function (address) {
-            url += "/api?module=account&action=txlist&address=" + address;
+            url += `/api?module=account&action=${contractAddress == null ? 'txlist' : 'tokentx'}&address=` + address;
             url += "&startblock=" + startBlock;
             url += "&endblock=" + endBlock;
             url += "&sort=asc" + apiKey;
+            if (contractAddress != null) url += "&contractaddress=" + contractAddress;
             _this.emit("debug", {
                 action: "request",
                 request: url,

--- a/packages/providers/lib/formatter.js
+++ b/packages/providers/lib/formatter.js
@@ -38,7 +38,7 @@ var Formatter = /** @class */ (function () {
             to: Formatter.allowNull(address, null),
             value: bigNumber,
             nonce: number,
-            data: data,
+            data: Formatter.allowNull(data, null),
             r: Formatter.allowNull(this.uint256),
             s: Formatter.allowNull(this.uint256),
             v: Formatter.allowNull(number),
@@ -242,7 +242,7 @@ var Formatter = /** @class */ (function () {
             transaction.to = "0x0000000000000000000000000000000000000000";
         }
         // Rename input to data
-        if (transaction.input != null && transaction.data == null) {
+        if (transaction.input != null && transaction.data == null && transaction.input !== 'deprecated') {
             transaction.data = transaction.input;
         }
         // If to and creates are empty, populate the creates from the transaction


### PR DESCRIPTION
The getHistory function uses an Etherscan API that supports getting transaction histories for ERC20 tokens, and ETH, but its current implementation only supports ETH. I've changed the getHistory function to take a contractAddress parameter that, if specified, calls the appropriate Etherscan API. If not specified, it defaults to the previous behaviour.