### PR TITLE
Do not throw on parseUnits if input truncatable

### DIFF
--- a/packages/bignumber/src.ts/fixednumber.ts
+++ b/packages/bignumber/src.ts/fixednumber.ts
@@ -96,7 +96,12 @@ export function parseFixed(value: string, decimals?: BigNumberish): BigNumber {
 
     // Prevent underflow
     if (fraction.length > multiplier.length - 1) {
-        throwFault("fractional component exceeds decimals", "underflow", "parseFixed");
+        // handle case 123.45600000
+        if (fraction.slice(multiplier.length, fraction.length) !== '0'.repeat(fraction.length-multiplier.length-1)) {
+            throwFault("fractional component exceeds decimals", "underflow", "parseFixed");
+        } else {
+            fraction = fraction.slice(0, multiplier.length)
+        }
     }
 
     // Fully pad the string with zeros to get to wei


### PR DESCRIPTION
Currently, if you do the following:

```
require('ethers').utils.parseUnits('123.4560000', 4)
```

`ethers.js` will raise an exception while it should simply remove the trailing 0 from the string before converting it. This PR does this.

I understand the need to raise an exception in more ambiguous cases (e.g. `parseUnits('123.45678', 4)` - should you `floor`, `round`, `ceil`, ... ?), but if there is trailing 0, this is a trivial case.