### PR TITLE
Bugfix:  unable to resolve "ws"

### DIFF
--- a/packages/providers/thirdparty.d.ts
+++ b/packages/providers/thirdparty.d.ts
@@ -1,5 +1,5 @@
 declare module "ws" {
-    export interface WebSocker {
+    export interface WebSocket {
         send(): void;
         onopen: () => void;
         onmessage: (messageEvent: { target: any, type: string, data: string }) => void


### PR DESCRIPTION
This typo broke ws module in react native:
Unable to resolve "ws" from "node_modules/@ethersproject/providers/lib/websocket-provider.js"