### PR TITLE
Typo on npm package name

### DIFF
--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -42,7 +42,7 @@ const {
     ContractReceipt,
     ContractTransaction
 
-} = require("@ethersproject/contract");
+} = require("@ethersproject/contracts");
 ```
 
 


### PR DESCRIPTION
point to https://www.npmjs.com/package/@ethersproject/contracts