### PR TITLE
Fix browser field in @ethersproject/web

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,7 +1,8 @@
 {
   "author": "Richard Moore <me@ricmoo.com>",
   "browser": {
-    "./lib/geturl": "./lib/browser-geturl.js"
+    "./lib/geturl": "./lib/browser-geturl.js",
+    "./lib.esm/geturl": "./lib.esm/browser-geturl.js"
   },
   "browser.esm": {
     "./lib.esm/geturl": "./lib.esm/browser-geturl.js"


### PR DESCRIPTION
This is required as only `"browser"` field is "standard" so tools like Rollup only look into it in a search for this alias map. 

What's the reason behind `"browser.esm"` and `"browser.umd"`? Are those handled by any tool? I haven't seen them in the wild up until now 😅 