### PR TITLE
Handle getBlockNumber errors on polling

### DIFF
--- a/packages/providers/src.ts/base-provider.ts
+++ b/packages/providers/src.ts/base-provider.ts
@@ -598,16 +598,8 @@ export class BaseProvider extends Provider implements EnsProvider {
 
         const checkInternalBlockNumber = resolveProperties({
             blockNumber: this.perform("getBlockNumber", { }),
-            networkError: this.getNetwork().then((network) => (null), (error) => (error))
-        }).then(({ blockNumber, networkError }) => {
-            if (networkError) {
-                // Unremember this bad internal block number
-                if (this._internalBlockNumber === checkInternalBlockNumber) {
-                    this._internalBlockNumber = null;
-                }
-                throw networkError;
-            }
-
+            networkError: this.getNetwork(),
+        }).then(({ blockNumber }) => {
             const respTime = getTime();
 
             blockNumber = BigNumber.from(blockNumber).toNumber();
@@ -616,6 +608,12 @@ export class BaseProvider extends Provider implements EnsProvider {
             this._maxInternalBlockNumber = blockNumber;
             this._setFastBlockNumber(blockNumber); // @TODO: Still need this?
             return { blockNumber, reqTime, respTime };
+        }).catch((error) => {
+            // Unremember this bad internal block number
+            if (this._internalBlockNumber === checkInternalBlockNumber) {
+                this._internalBlockNumber = null;
+            }
+            throw error;
         });
 
         this._internalBlockNumber = checkInternalBlockNumber;


### PR DESCRIPTION
Fixes #1084 
Fixes #1208 
Fixes #1221 

The error was caused by rejections at `this.perform("getBlockNumber", { })` in `BaseProvider._getInternalBlockNumber` causing `this._internalBlockNumber` to be a rejected promise, then rejecting every later `await internalBlockNumber` and preventing it from being cleared. The fix is to handle rejections here together with `getNetwork` changes, clearing the rejected promise variable and passing the error through. This will give the chance for the next `poll` to do a new request for the blockNumber.