### PR TITLE
Set expected priority sort order

### DIFF
--- a/packages/providers/src.ts/fallback-provider.ts
+++ b/packages/providers/src.ts/fallback-provider.ts
@@ -505,7 +505,7 @@ export class FallbackProvider extends BaseProvider {
         // Shuffle the providers and then sort them by their priority; we
         // shallowCopy them since we will store the result in them too
         const configs: Array<RunningConfig> = shuffled(this.providerConfigs.map(shallowCopy));
-        configs.sort((a, b) => (a.priority - b.priority));
+        configs.sort((a, b) => (b.priority - a.priority));
 
         const currentBlockNumber = this._highestBlockNumber;
 


### PR DESCRIPTION
The [docs](https://docs.ethers.io/v5/api/providers/other/#FallbackProviderConfig) state that `Higher priorities are favoured over lower priorities`.
Set the correct sort order for `priority`. 

If accepted I'm happy to setup and include tests.