### PR TITLE
Fix Ancillary package urls on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ everyone else with packages they do not need.
 
 We will keep a list of useful packages here.
 
-- `@ethersproject/experimental` ([documentation](https://docs.ethers.io))
-- `@ethersproject/cli` ([documentation](https://docs.ethers.io))
-- `@ethersproject/hardware-wallets` ([documentation](https://docs.ethers.io))
+- `@ethersproject/experimental` ([documentation](https://docs.ethers.io/v5/api/experimental/))
+- `@ethersproject/cli` ([documentation](https://docs.ethers.io/v5/cli/))
+- `@ethersproject/hardware-wallets` ([documentation](https://docs.ethers.io/v5/api/other/hardware/))
 
 
 License


### PR DESCRIPTION
The readme was pointing to the head of the documentation for Ancillary packages instead pointing directly at the relevant documentation.