### PR TITLE
Makes ContractInterface readonly.

### DIFF
--- a/packages/abi/src.ts/fragments.ts
+++ b/packages/abi/src.ts/fragments.ts
@@ -8,26 +8,26 @@ import { version } from "./_version";
 const logger = new Logger(version);
 
 export interface JsonFragmentType {
-    name?: string;
-    indexed?: boolean;
-    type?: string;
-    components?: Array<JsonFragmentType>;
+    readonly name?: string;
+    readonly indexed?: boolean;
+    readonly type?: string;
+    readonly components?: ReadonlyArray<JsonFragmentType>;
 }
 
 export interface JsonFragment {
-    name?: string;
-    type?: string;
+    readonly name?: string;
+    readonly type?: string;
 
-    anonymous?: boolean;
+    readonly anonymous?: boolean;
 
-    payable?: boolean;
-    constant?: boolean;
-    stateMutability?: string;
+    readonly payable?: boolean;
+    readonly constant?: boolean;
+    readonly stateMutability?: string;
 
-    inputs?: Array<JsonFragmentType>;
-    outputs?: Array<JsonFragmentType>;
+    readonly inputs?: ReadonlyArray<JsonFragmentType>;
+    readonly outputs?: ReadonlyArray<JsonFragmentType>;
 
-    gas?: string;
+    readonly gas?: string;
 };
 
 

--- a/packages/contracts/src.ts/index.ts
+++ b/packages/contracts/src.ts/index.ts
@@ -566,7 +566,7 @@ class WildcardRunningEvent extends RunningEvent {
     }
 }
 
-export type ContractInterface = string | Array<Fragment | JsonFragment | string> | Interface;
+export type ContractInterface = string | ReadonlyArray<Fragment | JsonFragment | string> | Interface;
 
 type InterfaceFunc = (contractInterface: ContractInterface) => Interface;
 


### PR DESCRIPTION
This allows someone to pass in something like:
```ts
const abi = [{ ... }] as const
```
Note that when you do `as const` you get the most narrow type possible, which is immutable (everything is `readonly`).  Currently, `ethers.Contract(..., abi, ...)` will fail because it wants a mutable `abi` in, despite the fact that it doesn't actually mutate it I believe.