### PR TITLE
Fix browser ESM example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Installing
 
 ```
 <script type="module">
-    import { ethers } from "https://cdn.ethers.io/lib/ethers-5.0.umd.min.js";
+    import { ethers } from "https://cdn.ethers.io/lib/ethers-5.0.esm.min.js";
 </script>
 ```
 


### PR DESCRIPTION
On the README the browser ESM example imports the UMD version. This PR switches to the ESM version.