### PR TITLE
Wrong output type for toBigInt

### DIFF
--- a/packages/bignumber/src.ts/bignumber.ts
+++ b/packages/bignumber/src.ts/bignumber.ts
@@ -190,7 +190,7 @@ export class BigNumber implements Hexable {
         return null;
     }
 
-    toBigInt(): BigInt {
+    toBigInt(): bigint {
         try {
             return BigInt(this.toString());
         } catch (e) { }


### PR DESCRIPTION
The type of an instance of `BigInt` is `bigint`.

This is important because if `a` and `b` are of type `BigInt`, we can't sum them for example...