### PR TITLE
Use `personal_sign` when injected web3provider is TrustWallet

### DIFF
--- a/packages/providers/src.ts/web3-provider.ts
+++ b/packages/providers/src.ts/web3-provider.ts
@@ -13,6 +13,7 @@ import { JsonRpcProvider } from "./json-rpc-provider";
 export type ExternalProvider = {
     isMetaMask?: boolean;
     isStatus?: boolean;
+    isTrust?: boolean;
     host?: string;
     path?: string;
     sendAsync?: (request: { method: string, params?: Array<any> }, callback: (error: any, response: any) => void) => void
@@ -30,7 +31,7 @@ function buildWeb3LegacyFetcher(provider: ExternalProvider, sendFunc: Web3Legacy
     return function(method: string, params: Array<any>): Promise<any> {
 
         // Metamask complains about eth_sign (and on some versions hangs)
-        if (method == "eth_sign" && (provider.isMetaMask || provider.isStatus)) {
+        if (method == "eth_sign" && (provider.isMetaMask || provider.isStatus || provider.isTrust)) {
             // https://github.com/ethereum/go-ethereum/wiki/Management-APIs#personal_sign
             method = "personal_sign";
             params = [ params[1], params[0] ];
@@ -65,7 +66,7 @@ function buildEip1193Fetcher(provider: ExternalProvider): JsonRpcFetchFunc {
         if (params == null) { params = [ ]; }
 
         // Metamask complains about eth_sign (and on some versions hangs)
-        if (method == "eth_sign" && (provider.isMetaMask || provider.isStatus)) {
+        if (method == "eth_sign" && (provider.isMetaMask || provider.isStatus || provider.isTrust)) {
             // https://github.com/ethereum/go-ethereum/wiki/Management-APIs#personal_sign
             method = "personal_sign";
             params = [ params[1], params[0] ];


### PR DESCRIPTION
# Summary

Using `personal_sign` instead of `eth_sign` for TrustWallet.

This sort of a follow up to my comment on a similar PR https://github.com/ethers-io/ethers.js/pull/1285#issuecomment-832211861

TrustWallet's `eth_sign` method does not properly encode the data.
With this workaround I'm able to perform the signing as expected.

The flag `isTrust` is set by TrustWallet's web3 provider https://github.com/trustwallet/trust-web3-provider/blob/93395938bb6838e35e3e358bcf952124131186fa/README.md#L15 similar to `isMetaMask` and `isStatus` flags.

According to [MM docs](https://docs.metamask.io/guide/signing-data.html#a-brief-history), `personal_sign` is preferred instead of `eth_sign`.

And now that I went through TrustWallet's web3 provider code I found out the reasoning for different choice of method: https://github.com/trustwallet/trust-web3-provider/pull/102#discussion_r495530950

Although, to be honest, I'm not 100% clear on that.

# Testing

Well, I would have published a RC npm package with these changes under my NPM account, or at a minimum publish it using [`yalc`](https://www.npmjs.com/package/yalc) locally, but setting up ethers.js is a bit tricky.
So I went with the good old "copy generated files to destination `node_modules` folder". And it worked as expected :)

If you insist, I can work on a minimum code sample.

