### PR TITLE
BigNumber: Add more arithmetic operations

### DIFF
--- a/packages/bignumber/src.ts/bignumber.ts
+++ b/packages/bignumber/src.ts/bignumber.ts
@@ -108,6 +108,28 @@ export class BigNumber implements Hexable {
         return toBigNumber(toBN(this).pow(value));
     }
 
+    neg(): BigNumber {
+        return toBigNumber(toBN(this).neg());
+    }
+
+    sqr(): BigNumber {
+        if (this._hex[0] === "-") {
+            throwFault("cannot 'sqr' negative values", "sqr");
+        }
+        return toBigNumber(toBN(this).sqr());
+    }
+
+    divMod(value: Number): BigNumber {
+        if (value == 0) {
+            throwFault("cannot 'divMod' value 0", "divMod");
+        }
+        return toBigNumber(toBN(this).divmod(value));
+    }
+
+    divRound(value: Number): BigNumber {
+        return toBigNumber(toBN(this).divRound(value));
+    }
+
     and(other: BigNumberish): BigNumber {
         const value = toBN(other);
         if (this.isNegative() || value.isNeg()) {

--- a/packages/bignumber/thirdparty.d.ts
+++ b/packages/bignumber/thirdparty.d.ts
@@ -8,6 +8,11 @@ declare module "bn.js" {
         mod(other: BN): BN;
         mul(other: BN): BN;
 
+        neg(): BN;
+        sqr(): BN;
+        divmod(other: Number): BN;
+        divRound(other: Number): BN;
+
         pow(other: BN): BN;
         umod(other: BN): BN;
 


### PR DESCRIPTION
Implements the neg(), sqr(), divMod() and divRound() arithmetic functions that are present in bn.js. This is in response to an [issue](https://github.com/ethers-io/ethers.js/issues/1541) where users requested support for these functions. 

If `ethers.BigNumber` is already using `pow`, I don't see any reason why It shouldn't use, for example, `sqr()` or any of the other arithmetic functions. If anything, it saves users the trouble of having to import multiple instances of bn.js or use some other dependency for something that's relatively easy to implement. 