### PR TITLE
fix typo: firectly -> directly

### DIFF
--- a/misc/admin/lib/geturl.js
+++ b/misc/admin/lib/geturl.js
@@ -73,7 +73,7 @@ function _getUrl(href, options) {
             options = {};
         }
         // @TODO: Once we drop support for node 8, we can pass the href
-        //        firectly into request and skip adding the components
+        //        directly into request and skip adding the components
         //        to this request object
         const url = url_1.parse(href);
         const request = {

--- a/misc/admin/src.ts/geturl.ts
+++ b/misc/admin/src.ts/geturl.ts
@@ -79,7 +79,7 @@ async function _getUrl(href: string, options?: Options): Promise<GetUrlResponse>
     if (options == null) { options = { }; }
 
     // @TODO: Once we drop support for node 8, we can pass the href
-    //        firectly into request and skip adding the components
+    //        directly into request and skip adding the components
     //        to this request object
     const url = parse(href);
 

--- a/packages/web/src.ts/geturl.ts
+++ b/packages/web/src.ts/geturl.ts
@@ -69,7 +69,7 @@ export async function getUrl(href: string, options?: Options): Promise<GetUrlRes
     if (options == null) { options = { }; }
 
     // @TODO: Once we drop support for node 8, we can pass the href
-    //        firectly into request and skip adding the components
+    //        directly into request and skip adding the components
     //        to this request object
     const url = parse(href);
 


### PR DESCRIPTION
This just fixes a typo.

Thanks for having created ethers.js and maintaining it 🙏 

We really would like to contribute more. Let us know if we can contribute more and what's currently urgent on the TODO-List.