### PR TITLE
Bug with TransactionResponse

### DIFF
--- a/docs/v5/api/contract/contract/README.md
+++ b/docs/v5/api/contract/contract/README.md
@@ -171,10 +171,10 @@ If the `wait()` method on the returned [TransactionResponse](/v5/api/providers/t
 - `receipt.events[n].decode` - a method that can be used to parse the log topics and data (this was used to compute `args`) 
 - `receipt.events[n].event` - the name of the event 
 - `receipt.events[n].eventSignature` - the full signature of the event 
-- `receipt.events.removeListener()` - a method to remove the listener that trigger this event 
-- `receipt.events.getBlock()` - a method to return the [Block](/v5/api/providers/types/#providers-Block) this event occurred in 
-- `receipt.events.getTransaction()` - a method to return the [Transaction](/v5/api/providers/types/#providers-TransactionResponse) this event occurred in 
-- `receipt.events.getTransactionReceipt()` - a method to return the [Transaction Receipt](/v5/api/providers/types/#providers-TransactionReceipt) this event occurred in 
+- `receipt.removeListener()` - a method to remove the listener that trigger this event 
+- `receipt.getBlock()` - a method to return the [Block](/v5/api/providers/types/#providers-Block) this event occurred in 
+- `receipt.getTransaction()` - a method to return the [Transaction](/v5/api/providers/types/#providers-TransactionResponse) this event occurred in 
+- `receipt.getTransactionReceipt()` - a method to return the [Transaction Receipt](/v5/api/providers/types/#providers-TransactionReceipt) this event occurred in 
 
 
 

--- a/docs/v5/api/contract/contract/README.md
+++ b/docs/v5/api/contract/contract/README.md
@@ -171,10 +171,10 @@ If the `wait()` method on the returned [TransactionResponse](/v5/api/providers/t
 - `receipt.events[n].decode` - a method that can be used to parse the log topics and data (this was used to compute `args`) 
 - `receipt.events[n].event` - the name of the event 
 - `receipt.events[n].eventSignature` - the full signature of the event 
-- `receipt.removeListener()` - a method to remove the listener that trigger this event 
-- `receipt.getBlock()` - a method to return the [Block](/v5/api/providers/types/#providers-Block) this event occurred in 
-- `receipt.getTransaction()` - a method to return the [Transaction](/v5/api/providers/types/#providers-TransactionResponse) this event occurred in 
-- `receipt.getTransactionReceipt()` - a method to return the [Transaction Receipt](/v5/api/providers/types/#providers-TransactionReceipt) this event occurred in 
+- `receipt.events.removeListener()` - a method to remove the listener that trigger this event 
+- `receipt.events.getBlock()` - a method to return the [Block](/v5/api/providers/types/#providers-Block) this event occurred in 
+- `receipt.events.getTransaction()` - a method to return the [Transaction](/v5/api/providers/types/#providers-TransactionResponse) this event occurred in 
+- `receipt.events.getTransactionReceipt()` - a method to return the [Transaction Receipt](/v5/api/providers/types/#providers-TransactionReceipt) this event occurred in 
 
 
 

--- a/packages/contracts/src.ts/index.ts
+++ b/packages/contracts/src.ts/index.ts
@@ -373,20 +373,20 @@ function buildSend(contract: Contract, fragment: FunctionFragment): ContractFunc
                         event.eventSignature = parsed.signature;
                     }
 
-                    // Useful operations
-                    event.removeListener = () => { return contract.provider; }
-                    event.getBlock = () => {
-                        return contract.provider.getBlock(receipt.blockHash);
-                    }
-                    event.getTransaction = () => {
-                        return contract.provider.getTransaction(receipt.transactionHash);
-                    }
-                    event.getTransactionReceipt = () => {
-                        return Promise.resolve(receipt);
-                    }
-
                     return event;
                 });
+                
+                // Useful operations
+                receipt.removeListener = () => { return contract.provider; }
+                receipt.getBlock = () => {
+                    return contract.provider.getBlock(receipt.blockHash);
+                }
+                receipt.getTransaction = () => {
+                    return contract.provider.getTransaction(receipt.transactionHash);
+                }
+                receipt.getTransactionReceipt = () => {
+                    return Promise.resolve(receipt);
+                }
 
                 return receipt;
             });


### PR DESCRIPTION
Hi, there is a bug in the TransactionResponse.

# Description of error

![image](https://user-images.githubusercontent.com/17739166/122628959-046c5580-d0ec-11eb-9f81-bd9b149a5d19.png)

These 4 functions are not accessible from the receipt directly. In the codebase, you need to access the events before you can access these functions. 

https://github.com/ethers-io/ethers.js/blob/master/packages/contracts/src.ts/index.ts#L377-L385

# Description of fix

Moved these 4 functions out to the parent receipt object.
