### PR TITLE
Fix handling of empty credentials

### DIFF
--- a/packages/web/src.ts/index.ts
+++ b/packages/web/src.ts/index.ts
@@ -134,7 +134,7 @@ export function _fetchData<T = Uint8Array>(connection: string | ConnectionInfo, 
 
         options.allowGzip = !!connection.allowGzip;
 
-        if (connection.user != null && connection.password != null) {
+        if (connection.user && connection.password) {
             if (url.substring(0, 6) !== "https:" && connection.allowInsecureAuthentication !== true) {
                 logger.throwError(
                     "basic authentication requires a secure https url",


### PR DESCRIPTION
In https://github.com/graphprotocol/indexer/issues/256 I have faced that if empty credentials passed Auth header still exists (this makes requests fails on my providers eth node).

I'm a noob in TS but here's what I have found:
* string? type could be string or undefined. Current check doesn't handles empty string and undefined cases.
* string? couldn't be set to null due to type check (as far as i understood from my IDE warnings)
* if string check checks if null, if string undefined and if string empty as I googled.

So I suppose this should fix cases when Auth header passed for providers without properly configured auth credentials and shouldn't break anything

/closes https://github.com/ethers-io/ethers.js/issues/1701