### PR TITLE
Support matic and mumbai testnet through Infura

### DIFF
--- a/docs.wrm/api/providers/api-providers.wrm
+++ b/docs.wrm/api/providers/api-providers.wrm
@@ -111,6 +111,8 @@ _definition: **Supported Networks**
 - Rinkeby (proof-of-authority testnet)
 - G&ouml;rli (clique testnet)
 - Kovan (proof-of-authority testnet)
+- Matic (Polygon/Matic proof-of-stake mainnet, anchored to ethereum mainnet)
+- Maticmum (Polygon/Matic proof-of-stake testnet, achored to ethereum goerli)
 
 _code: INFURA Examples @lang<javascript>
 

--- a/packages/providers/lib/infura-provider.js
+++ b/packages/providers/lib/infura-provider.js
@@ -98,6 +98,12 @@ var InfuraProvider = /** @class */ (function (_super) {
             case "goerli":
                 host = "goerli.infura.io";
                 break;
+            case "matic":
+                host = "polygon-mainnet.infura.io";
+                break;
+            case "maticmum":
+                host = "polygon-mumbai.infura.io";
+                break;
             default:
                 logger.throwError("unsupported network", logger_1.Logger.errors.INVALID_ARGUMENT, {
                     argument: "network",

--- a/packages/providers/src.ts/infura-provider.ts
+++ b/packages/providers/src.ts/infura-provider.ts
@@ -99,6 +99,12 @@ export class InfuraProvider extends UrlJsonRpcProvider {
             case "goerli":
                 host = "goerli.infura.io";
                 break;
+            case "matic":
+                host = "polygon-mainnet.infura.io";
+                break;
+            case "maticmum":
+                host = "polygon-mumbai.infura.io";
+                break;
             default:
                 logger.throwError("unsupported network", Logger.errors.INVALID_ARGUMENT, {
                     argument: "network",


### PR DESCRIPTION
Support for the (currently free) access to Polygon/Matic and it's testnet through Infura.
Followed the naming convention matic and maticmum for mainnet and mumbai testnet as specified in the network chain id list.