### PR TITLE
WebSocketProvider: make `url` constructor argument optional

### DIFF
--- a/packages/providers/src.ts/websocket-provider.ts
+++ b/packages/providers/src.ts/websocket-provider.ts
@@ -56,7 +56,7 @@ export class WebSocketProvider extends JsonRpcProvider {
 
     _wsReady: boolean;
 
-    constructor(url: string, network?: Networkish) {
+    constructor(url?: string, network?: Networkish) {
         // This will be added in the future; please open an issue to expedite
         if (network === "any") {
             logger.throwError("WebSocketProvider does not support 'any' network yet", Logger.errors.UNSUPPORTED_OPERATION, {


### PR DESCRIPTION
Make the argument optional so that we can take advantage of the default value.