### PR TITLE
bytes: fix isBytes check

### DIFF
--- a/packages/bytes/src.ts/index.ts
+++ b/packages/bytes/src.ts/index.ts
@@ -75,11 +75,11 @@ export function isBytes(value: any): value is Bytes {
 
     if (value.constructor === Uint8Array) { return true; }
     if (typeof(value) === "string") { return false; }
-    if (value.length == null) { return false; }
+    if (!Number.isInteger(value.length) || value.length < 0) { return false; }
 
     for (let i = 0; i < value.length; i++) {
         const v = value[i];
-        if (typeof(v) !== "number" || v < 0 || v >= 256 || (v % 1)) {
+        if (!Number.isInteger(v) || v < 0 || v >= 256) {
             return false;
         }
     }


### PR DESCRIPTION
Otherwise this passed on e.g. an array of `NaN`s.

As a rule of thumb, using fail-closed checks is safer than using fail-open checks, e.g. `if (!(...check for good values)) fail` is safer than `if (check for bad values) fail`, as e.g. `NaN` here bypasses any of those, returning falsy on every of `v < 0`, `v >= 256` and `v % 1` checks.

Refs:
 * #1172
 * https://tc39.es/ecma262/#sec-number.isinteger