### PR TITLE
bignumber: fix ida in regex

### DIFF
--- a/packages/bignumber/src.ts/fixednumber.ts
+++ b/packages/bignumber/src.ts/fixednumber.ts
@@ -95,7 +95,7 @@ export function parseFixed(value: string, decimals?: BigNumberish): BigNumber {
 
     // Get significant digits to check truncation for underflow
     {
-    const sigFraction = fraction.replace(/^([0-9]*?)(0*)$/, (all, sig, zeros) => (sig));
+    const sigFraction = fraction.replace(/^([0-9]*[1-9])?0*$/, (all, sig) => (sig || ''));
         if (sigFraction.length > multiplier.length - 1) {
             throwFault("fractional component exceeds decimals", "underflow", "parseFixed");
         }


### PR DESCRIPTION
Fixes https://github.com/ethers-io/ethers.js/issues/1975.

Note: it fixes only the ReDoS part of the problem without touching the logic, but the same a9cdbe1238c149a7167c6bb1a78f314805b52755 commit also introduced an actual logic problem resulting in a miscalculation, see #1974.