### PR TITLE
random: fix browser version length check

### DIFF
--- a/packages/random/src.ts/browser-random.ts
+++ b/packages/random/src.ts/browser-random.ts
@@ -34,7 +34,7 @@ if (!crypto || !crypto.getRandomValues) {
 }
 
 export function randomBytes(length: number): Uint8Array {
-    if (length <= 0 || length > 1024 || (length % 1)) {
+    if (!Number.isInteger(length) || length <= 0 || length > 1024) {
         logger.throwArgumentError("invalid length", "length", length);
     }
 


### PR DESCRIPTION
E.g. `new Uint8Array(NaN)` creates a 0-length array, but we don't want `randomBytes(NaN)` to silently return a zero-length array, we want it to throw like the non-browser version does.