### PR TITLE
Fix formatting for pending blocks

### DIFF
--- a/packages/providers/src.ts/formatter.ts
+++ b/packages/providers/src.ts/formatter.ts
@@ -130,7 +130,8 @@ export class Formatter {
         };
 
         formats.block = {
-            hash: hash,
+            // May be `null` if it's a 'pending' block
+            hash: Formatter.allowNull(hash),
             parentHash: hash,
             number: number,
 
@@ -141,7 +142,8 @@ export class Formatter {
             gasLimit: bigNumber,
             gasUsed: bigNumber,
 
-            miner: address,
+            // May be `null` if it's a 'pending' block
+            miner: Formatter.allowNull(address),
             extraData: data,
 
             transactions: Formatter.allowNull(Formatter.arrayOf(hash)),


### PR DESCRIPTION
If we fetch a `'pending'` block, `hash` and `miner` are null. Currently, calling `getBlock('pending')` fails with the following error:

```
invalid hash (argument="value", value=null, code=INVALID_ARGUMENT, version=providers/5.4.4)
```