### PR TITLE
Resolve getDefaultProvider network type mismatch

### DIFF
--- a/packages/providers/src.ts/index.ts
+++ b/packages/providers/src.ts/index.ts
@@ -43,7 +43,7 @@ const logger = new Logger(version);
 ////////////////////////
 // Helper Functions
 
-function getDefaultProvider(network?: Network | string, options?: any): BaseProvider {
+function getDefaultProvider(network?: Networkish, options?: any): BaseProvider {
     if (network == null) { network = "homestead"; }
 
     // If passed a URL, figure out the right type of provider based on the scheme


### PR DESCRIPTION
getNetwork accepts type Networkish (Network | string | number) allowing users to specify chainId if they don't have the entire Network object.  This functionality should still be maintained for ease of use but will throw type errors for users at the moment.