### PR TITLE
Fix LedgerSigner for EIP1559

### DIFF
--- a/packages/hardware-wallets/src.ts/ledger.ts
+++ b/packages/hardware-wallets/src.ts/ledger.ts
@@ -100,9 +100,12 @@ export class LedgerSigner extends ethers.Signer {
             data: (tx.data || undefined),
             gasLimit: (tx.gasLimit || undefined),
             gasPrice: (tx.gasPrice || undefined),
+            maxFeePerGas: (tx.maxFeePerGas || undefined),
+            maxPriorityFeePerGas: (tx.maxPriorityFeePerGas || undefined),
             nonce: (tx.nonce ? ethers.BigNumber.from(tx.nonce).toNumber(): undefined),
             to: (tx.to || undefined),
             value: (tx.value || undefined),
+            type: (tx.type || undefined),
         };
 
         const unsignedTx = ethers.utils.serializeTransaction(baseTx).substring(2);


### PR DESCRIPTION
The current LedgerSigner does not pass the correct TX parameters for EIP1559, which results in the gas price being zero and therefore the transaction never being sent.