### PR TITLE
Fix `interface.functions` fragment name conflict with `Object` prototype keys

### DIFF
--- a/packages/contracts/src.ts/index.ts
+++ b/packages/contracts/src.ts/index.ts
@@ -696,7 +696,7 @@ export class BaseContract {
             }
         }
 
-        const uniqueNames = new Map<string, Array<string>>();
+        const uniqueNames: { [ name: string ]: Array<string> } = Object.create(null);
         const uniqueSignatures: { [ signature: string ]: boolean } = { };
         Object.keys(this.interface.functions).forEach((signature) => {
             const fragment = this.interface.functions[signature];
@@ -713,10 +713,8 @@ export class BaseContract {
             // are ambiguous
             {
                 const name = fragment.name;
-                if (!uniqueNames.has(name)) {
-                    uniqueNames.set(name, []);
-                }
-                uniqueNames.get(name).push(signature);
+                if (!uniqueNames[name]) { uniqueNames[name] = [ ]; }
+                uniqueNames[name].push(signature);
             }
 
             if ((<Contract>this)[signature] == null) {
@@ -746,7 +744,7 @@ export class BaseContract {
         Object.keys(uniqueNames).forEach((name) => {
 
             // Ambiguous names to not get attached as bare names
-            const signatures = uniqueNames.get(name);
+            const signatures = uniqueNames[name];
             if (signatures.length > 1) { return; }
 
             const signature = signatures[0];

--- a/packages/contracts/src.ts/index.ts
+++ b/packages/contracts/src.ts/index.ts
@@ -696,7 +696,7 @@ export class BaseContract {
             }
         }
 
-        const uniqueNames: { [ name: string ]: Array<string> } = { };
+        const uniqueNames = new Map<string, Array<string>>();
         const uniqueSignatures: { [ signature: string ]: boolean } = { };
         Object.keys(this.interface.functions).forEach((signature) => {
             const fragment = this.interface.functions[signature];
@@ -713,8 +713,10 @@ export class BaseContract {
             // are ambiguous
             {
                 const name = fragment.name;
-                if (!uniqueNames[name]) { uniqueNames[name] = [ ]; }
-                uniqueNames[name].push(signature);
+                if (!uniqueNames.has(name)) {
+                    uniqueNames.set(name, []);
+                }
+                uniqueNames.get(name).push(signature);
             }
 
             if ((<Contract>this)[signature] == null) {
@@ -744,7 +746,7 @@ export class BaseContract {
         Object.keys(uniqueNames).forEach((name) => {
 
             // Ambiguous names to not get attached as bare names
-            const signatures = uniqueNames[name];
+            const signatures = uniqueNames.get(name);
             if (signatures.length > 1) { return; }
 
             const signature = signatures[0];

--- a/packages/tests/src.ts/test-contract-interface.ts
+++ b/packages/tests/src.ts/test-contract-interface.ts
@@ -669,4 +669,14 @@ describe("Additional test cases", function() {
         const tx = iface.encodeFunctionData("test", [ "c1912fee45d61c87cc5ea59dae31190fffff232d" ]);
         console.log(tx);
     });
+
+    // https://github.com/ethers-io/ethers.js/issues/2054
+    it("`interface.functions` fragment names do not conflict with prototype keys", () => {
+        const contract = new ethers.Contract(
+            "0x0000000000000000000000000000000000000000",
+            ["function toString() external", "function valueOf() external"]
+        );
+        assert.equal(typeof contract["toString()"], "function", "set correct toString() property");
+        assert.equal(typeof contract["valueOf()"], "function", "set correct valueOf() property");
+    });
 });


### PR DESCRIPTION
Fixes #2054