### PR TITLE
Add Arbitrum networks

### DIFF
--- a/packages/networks/src.ts/index.ts
+++ b/packages/networks/src.ts/index.ts
@@ -179,6 +179,9 @@ const networks: { [name: string]: Network } = {
 
     bnb: { chainId: 56, name: "bnb" },
     bnbt: { chainId: 97, name: "bnbt" },
+    
+    arbitrumOne: { chainId: 42161, name: "arbitrumOne" },
+    arbitrumRinkeby: { chainId: 421611, name: "arbitrumRinkeby" },
 }
 
 /**


### PR DESCRIPTION
Adding Arbitrum One and Arbitrum Rinkeby (testnet).

Source:
* https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-42161.json
* https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-421611.json