### PR TITLE
contracts: fix bad prototype logic

### DIFF
--- a/packages/contracts/src.ts/index.ts
+++ b/packages/contracts/src.ts/index.ts
@@ -652,7 +652,7 @@ export class BaseContract {
         defineReadOnly(this, "filters", { });
 
         {
-            const uniqueFilters: { [ name: string ]: Array<string> } = { };
+            const uniqueFilters: { [ name: string ]: Array<string> } = Object.create(null);
             Object.keys(this.interface.events).forEach((eventSignature) => {
                 const event = this.interface.events[eventSignature];
                 defineReadOnly(this.filters, eventSignature, (...args: Array<any>) => {
@@ -696,8 +696,8 @@ export class BaseContract {
             }
         }
 
-        const uniqueNames: { [ name: string ]: Array<string> } = { };
-        const uniqueSignatures: { [ signature: string ]: boolean } = { };
+        const uniqueNames: { [ name: string ]: Array<string> } = Object.create(null);
+        const uniqueSignatures: { [ signature: string ]: boolean } = Object.create(null);
         Object.keys(this.interface.functions).forEach((signature) => {
             const fragment = this.interface.functions[signature];
 


### PR DESCRIPTION
Otherwise, if `event.name === "__proto__"`, this logic would hit a setter and wouldn't do what it's expected to do.

This fix should affect anything else as the `unique****` objects are local, temporary and references to them are not exported outside of the function.

Some other packages have similar issues, but it's a bit harder to fix them there without bumping to modern es, I'll file separate PRs later.