### PR TITLE
fix(doc): incorrect return type for ContractFactory's connect function

### DIFF
--- a/docs.wrm/api/contract/contract-factory.wrm
+++ b/docs.wrm/api/contract/contract-factory.wrm
@@ -23,7 +23,7 @@ Consumes the output of the Solidity compiler, extracting the ABI
 and bytecode from it, allowing for the various formats the solc
 compiler has emitted over its life.
 
-_property: contractFactory.connect(signer) => [[Contract]] @<ContractFactory-connect>
+_property: contractFactory.connect(signer) => [[ContractFactory]] @<ContractFactory-connect>
 
 Returns a **new instance** of the ContractFactory with the same //interface//
 and //bytecode//, but with a different //signer//.


### PR DESCRIPTION
- Fixed typo for `ContractFactory`'s connect method signature return type (`Contract` => `ContractFactory`)