### PR TITLE
Use case-insensitive scheme for http and ws.

### DIFF
--- a/packages/providers/src.ts/index.ts
+++ b/packages/providers/src.ts/index.ts
@@ -53,7 +53,7 @@ function getDefaultProvider(network?: Networkish, options?: any): BaseProvider {
         // Handle http and ws (and their secure variants)
         const match = network.match(/^(ws|http)s?:/i);
         if (match) {
-            switch (match[1]) {
+            switch (match[1].toLocaleLowerCase()) {
                 case "http":
                     return new JsonRpcProvider(network);
                 case "ws":


### PR DESCRIPTION
`ethers.providers.getDefaultProvider('HTTP://127.0.0.1:7545')` will throw Error

Although I've already tested it locally, please test it again