### PR TITLE
feat(request): add signal for AbortController

### DIFF
--- a/packages/web/src.ts/browser-geturl.ts
+++ b/packages/web/src.ts/browser-geturl.ts
@@ -15,6 +15,8 @@ export async function getUrl(href: string, options?: Options): Promise<GetUrlRes
         body: (options.body || undefined),
     };
 
+    if (options.signal) request.signal = options.signal
+
     if (options.skipFetchSetup !== true) {
         request.mode = <RequestMode>"cors";              // no-cors, cors, *same-origin
         request.cache = <RequestCache>"no-cache";        // *default, no-cache, reload, force-cache, only-if-cached

--- a/packages/web/src.ts/index.ts
+++ b/packages/web/src.ts/index.ts
@@ -50,6 +50,7 @@ export type ConnectionInfo = {
     throttleCallback?: (attempt: number, url: string) => Promise<boolean>,
 
     timeout?: number,
+    signal?: AbortSignal;
 };
 
 export interface OnceBlockable {
@@ -149,6 +150,8 @@ export function _fetchData<T = Uint8Array>(connection: string | ConnectionInfo, 
                 value: "Basic " + base64Encode(toUtf8Bytes(authorization))
             };
         }
+
+        options.signal = connection.signal
     }
     const reData = new RegExp("^data:([a-z0-9-]+/[a-z0-9-]+);base64,(.*)$", "i");
     const dataMatch = ((url) ? url.match(reData): null);

--- a/packages/web/src.ts/types.ts
+++ b/packages/web/src.ts/types.ts
@@ -13,5 +13,6 @@ export type Options = {
     body?: Uint8Array;
     headers?: { [ key: string] : string };
     skipFetchSetup?: boolean;
+    signal?: AbortSignal;
 };
 


### PR DESCRIPTION
Hi

In my project, I need to use request interrupt([AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController)). So I expanded ConnectionInfo(fetchJson props). 

