### PR TITLE
fix: minor typo (JavScript) on docs >> BigNumber

### DIFF
--- a/docs.wrm/api/utils/bignumber.wrm
+++ b/docs.wrm/api/utils/bignumber.wrm
@@ -169,7 +169,7 @@ Returns true if and only if the value of //BigNumber// is zero.
 _heading: Conversion
 
 _property: BigNumber.toBigInt() => bigint  @SRC<bignumber>
-Returns the value of //BigNumber// as a [JavScript BigInt](link-js-bigint) value,
+Returns the value of //BigNumber// as a [JavaScript BigInt](link-js-bigint) value,
 on platforms which support them.
 
 _property: BigNumber.toNumber() => number  @SRC<bignumber>


### PR DESCRIPTION
A one-character typo fix for the [BigNumber documentation](https://docs.ethers.io/v5/api/utils/bignumber/#BigNumber--BigNumber--methods--conversion)