### PR TITLE
add moonriver and moonbase to networks

### DIFF
--- a/packages/networks/src.ts/index.ts
+++ b/packages/networks/src.ts/index.ts
@@ -190,6 +190,7 @@ const networks: { [name: string]: Network } = {
 
     moonriver: { chainId: 1285, name: "moonriver" },
     moonbase: { chainId: 1287, name: "moonbase" },
+    moonbeam: { chainId: 1284, name: "moonbeam" }
 }
 
 /**

--- a/packages/networks/src.ts/index.ts
+++ b/packages/networks/src.ts/index.ts
@@ -187,6 +187,9 @@ const networks: { [name: string]: Network } = {
 
     bnb: { chainId: 56, name: "bnb" },
     bnbt: { chainId: 97, name: "bnbt" },
+
+    moonriver: { chainId: 1285, name: "moonriver" },
+    moonbase: { chainId: 1287, name: "moonbase" },
 }
 
 /**


### PR DESCRIPTION
This PR adds support for the [Moonbase Alpha](https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-1287.json) TestNet, [Moonriver](https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-1285.json), and [Moonbeam](https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-1284.json)