### PR TITLE
Lowercase avatar scheme to match regex and fix comparisons in `provider.getAvatar`

### DIFF
--- a/packages/providers/src.ts/base-provider.ts
+++ b/packages/providers/src.ts/base-provider.ts
@@ -417,8 +417,9 @@ export class Resolver implements EnsResolver {
             for (let i = 0; i < matchers.length; i++) {
                 const match = avatar.match(matchers[i]);
                 if (match == null) { continue; }
+                const avatarScheme = match[1].toLowerCase();
 
-                switch (match[1]) {
+                switch (avatarScheme) {
                     case "https":
                         linkage.push({ type: "url", content: avatar });
                         return { linkage, url: avatar };
@@ -434,8 +435,8 @@ export class Resolver implements EnsResolver {
                     case "erc721":
                     case "erc1155": {
                         // Depending on the ERC type, use tokenURI(uint256) or url(uint256)
-                        const selector = (match[1] === "erc721") ? "0xc87b56dd": "0x0e89341c";
-                        linkage.push({ type: match[1], content: avatar });
+                        const selector = (avatarScheme === "erc721") ? "0xc87b56dd": "0x0e89341c";
+                        linkage.push({ type: avatarScheme, content: avatar });
 
                         // The owner of this name
                         const owner = (this._resolvedAddress || await this.getAddress());
@@ -447,7 +448,7 @@ export class Resolver implements EnsResolver {
                         const tokenId = hexZeroPad(BigNumber.from(comps[1]).toHexString(), 32);
 
                         // Check that this account owns the token
-                        if (match[1] === "erc721") {
+                        if (avatarScheme === "erc721") {
                             // ownerOf(uint256 tokenId)
                             const tokenOwner = this.provider.formatter.callAddress(await this.provider.call({
                                 to: addr, data: hexConcat([ "0x6352211e", tokenId ])
@@ -455,7 +456,7 @@ export class Resolver implements EnsResolver {
                             if (owner !== tokenOwner) { return null; }
                             linkage.push({ type: "owner", content: tokenOwner });
 
-                        } else if (match[1] === "erc1155") {
+                        } else if (avatarScheme === "erc1155") {
                             // balanceOf(address owner, uint256 tokenId)
                             const balance = BigNumber.from(await this.provider.call({
                                 to: addr, data: hexConcat([ "0x00fdd58e", hexZeroPad(owner, 32), tokenId ])
@@ -474,7 +475,7 @@ export class Resolver implements EnsResolver {
                         linkage.push({ type: "metadata-url", content: metadataUrl });
 
                         // ERC-1155 allows a generic {id} in the URL
-                        if (match[1] === "erc1155") {
+                        if (avatarScheme === "erc1155") {
                             metadataUrl = metadataUrl.replace("{id}", tokenId.substring(2));
                             linkage.push({ type: "metadata-url-expanded", content: metadataUrl });
                         }


### PR DESCRIPTION
`provider.getAvatar` uses a case insensitive matcher for schemes like https, data, ipfs, and eip155. However, when we extract the matched value and use it in switch statements and conditionals later on, we expect it to be lowercase already, which breaks comparisons if you e.g. use `ERC721` instead of `erc721` in your avatar field.

ENS already knows how to resolve these casing discrepancies, which you can see here (note the avatar image loading): https://app.ens.domains/name/nptacek.eth/details
![image](https://user-images.githubusercontent.com/508855/148146399-038135f2-bea7-4493-928b-6641ed1320a4.png)

However, ethers' `getAvatar` for this name (`nptacek.eth`) fails and returns `null`.

This PR ensures we lowercase the captured match for the avatar scheme and uses it in place of the actual match (which may or may not have uppercase characters).

Happy to add tests if I get some guidance on how best to update the mock data!