### PR TITLE
[Provider] Support fetching avatar metadata stored in ipfs

### DIFF
--- a/packages/providers/src.ts/base-provider.ts
+++ b/packages/providers/src.ts/base-provider.ts
@@ -491,6 +491,7 @@ export class Resolver implements EnsResolver {
                             case "http:":
                             case "https:":
                                 metadata = yield fetchJson(metadataUrl);
+                                break;
                         }
                         
                         const metadata = await fetchJson(metadataUrl);

--- a/packages/providers/src.ts/base-provider.ts
+++ b/packages/providers/src.ts/base-provider.ts
@@ -482,6 +482,17 @@ export class Resolver implements EnsResolver {
                         }
 
                         // Get the token metadata
+                        const url = new URL(metadataUrl);
+                        let metadata = null;
+                        switch (url.protocol) {
+                            case "ipfs:":
+                                metadata = yield fetchJson(getIpfsLink(url.pathname));
+                                break;
+                            case "http:":
+                            case "https:":
+                                metadata = yield fetchJson(metadataUrl);
+                        }
+                        
                         const metadata = await fetchJson(metadataUrl);
                         if (!metadata) { return null; }
                         linkage.push({ type: "metadata", content: JSON.stringify(metadata) });


### PR DESCRIPTION
The issue can be reproduced by trying to fetch the avatar for "vitalik.eth" 

Error: `contentScript.bundle.js:2155 Fetch API cannot load ipfs://ipfs/QmYTuHaoY1winNAxmf7JmCmSrkChuMAAnqgSuJBTiWZe9f. URL scheme "ipfs" is not supported.`


The image url is still not entirely correct since the current logic expects the URI to be `ipfs://{CID}` but the URI returned from the metadata is `ipfs://ipfs/{CID}`. Any suggestions on the best way to handle this?