### PR TITLE
add timeout arg for TransactionResponse#wait

### DIFF
--- a/packages/abstract-provider/lib/index.d.ts
+++ b/packages/abstract-provider/lib/index.d.ts
@@ -27,7 +27,7 @@ export interface TransactionResponse extends Transaction {
     confirmations: number;
     from: string;
     raw?: string;
-    wait: (confirmations?: number) => Promise<TransactionReceipt>;
+    wait: (confirmations?: number, timeout?: number) => Promise<TransactionReceipt>;
 }
 export declare type BlockTag = string | number;
 export interface _Block {

--- a/packages/contracts/src.ts/index.ts
+++ b/packages/contracts/src.ts/index.ts
@@ -325,8 +325,8 @@ function buildEstimate(contract: Contract, fragment: FunctionFragment): Contract
 
 function addContractWait(contract: Contract, tx: TransactionResponse) {
     const wait = tx.wait.bind(tx);
-    tx.wait = (confirmations?: number) => {
-        return wait(confirmations).then((receipt: ContractReceipt) => {
+    tx.wait = (confirmations?: number, timeout?: number) => {
+        return wait(confirmations, timeout).then((receipt: ContractReceipt) => {
             receipt.events = receipt.logs.map((log) => {
                 let event: Event = (<Event>deepCopy(log));
                 let parsed: LogDescription = null;


### PR DESCRIPTION
Add the `timeout` argument for `TransactionResponse#wait`. It was introduced in [this commit](https://github.com/ethers-io/ethers.js/commit/5144acf456b51c95bbe3950bd37609abecc7ebc7?diff=unified), but the `interface` was not updated