### PR TITLE
Updated Steps to connect to MetaMask

### DIFF
--- a/docs/v5/getting-started/README.md
+++ b/docs/v5/getting-started/README.md
@@ -56,6 +56,9 @@ Connecting to Ethereum: Metamask
 // what Metamask injects as window.ethereum into each page
 const provider = new ethers.providers.Web3Provider(window.ethereum)
 
+// Prompt user for account connections.
+await provider.send("eth_requestAccounts", []);
+
 // The Metamask plugin also allows signing transactions to
 // send ether and pay to change state within the blockchain.
 // For this, you need the account signer...


### PR DESCRIPTION
Added step to prompt user for account connections before calling the getSinger().

_The method ethereum.enable() was deprecated in place of .send('eth_requestAccounts') as per [ eips.ethereum.org/EIPS/eip-1102](https://eips.ethereum.org/EIPS/eip-1102). So we should update the documentation._