### PR TITLE
fix: add isCoinbaseWallet property to ExternalProvider

### DIFF
--- a/packages/providers/src.ts/web3-provider.ts
+++ b/packages/providers/src.ts/web3-provider.ts
@@ -13,6 +13,7 @@ import { JsonRpcProvider } from "./json-rpc-provider";
 export type ExternalProvider = {
     isMetaMask?: boolean;
     isStatus?: boolean;
+    isCoinbaseWallet: boolean;
     host?: string;
     path?: string;
     sendAsync?: (request: { method: string, params?: Array<any> }, callback: (error: any, response: any) => void) => void


### PR DESCRIPTION
Adds a property easily detecting if wallet is a Coinbase Wallet client. Will enable removing @ts-ignore in many code snippets similar to https://github.com/aave/aave-ui/pull/394/files#diff-c66fc2323429a6c3e7c2e2027fd1d39278007294f26f91c88f4329281f3f1d5eR84