### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs.wrm/api/providers/types.wrm
+++ b/docs.wrm/api/providers/types.wrm
@@ -285,7 +285,7 @@ transaction was mined.
 
 _property: transaction.raw => string<[[DataHexString]]>
 The serialized transaction. This may be null as some backends do not
-rpopulate it. If this is required, it can be computed from a **TransactionResponse**
+repopulate it. If this is required, it can be computed from a **TransactionResponse**
 object using [this cookbook recipe](cookbook--compute-raw-transaction).
 
 _property: transaction.wait([ confirms = 1 ]) => Promise<[[providers-TransactionReceipt]]>


### PR DESCRIPTION
Not sure if this was meant to be repopulate or populate, just put repopulate because it had the "r" in front of populate.