### PR TITLE
Add missing type of `timeout` arg of TransactionResponse.wait

### DIFF
--- a/docs.wrm/api/providers/types.wrm
+++ b/docs.wrm/api/providers/types.wrm
@@ -288,10 +288,15 @@ The serialized transaction. This may be null as some backends do not
 rpopulate it. If this is required, it can be computed from a **TransactionResponse**
 object using [this cookbook recipe](cookbook--compute-raw-transaction).
 
-_property: transaction.wait([ confirms = 1 ]) => Promise<[[providers-TransactionReceipt]]>
+_property: transaction.wait([ confirms = 1 [ , timeout = 0 ] ]) => Promise<[[providers-TransactionReceipt]]>
 Resolves to the [[providers-TransactionReceipt]] once the transaction
 has been included in the chain for //confirms// blocks. If //confirms//
 is 0, and the transaction has not been mined, ``null`` is returned.
+
+//timeout// can be used to specifiy how long to wait for the transaction
+to be reached the provided number of confirmations. If the wait process
+takes as much time as //timeout// value, [TIMEOUT](errors--timeout) error
+will be rejected with provided //timeout// value in ``error.timeout``.
 
 If the transaction execution failed (i.e. the receipt status is ``0``),
 a [CALL_EXCEPTION](errors--call-exception) error will be rejected with

--- a/packages/abstract-provider/src.ts/index.ts
+++ b/packages/abstract-provider/src.ts/index.ts
@@ -53,7 +53,7 @@ export interface TransactionResponse extends Transaction {
     raw?: string,
 
     // This function waits until the transaction has been mined
-    wait: (confirmations?: number) => Promise<TransactionReceipt>
+    wait: (confirmations?: number, timeout?: number) => Promise<TransactionReceipt>
 };
 
 export type BlockTag = string | number;

--- a/packages/providers/src.ts/json-rpc-provider.ts
+++ b/packages/providers/src.ts/json-rpc-provider.ts
@@ -296,7 +296,7 @@ class UncheckedJsonRpcSigner extends JsonRpcSigner {
                 chainId: null,
                 confirmations: 0,
                 from: null,
-                wait: (confirmations?: number) => { return this.provider.waitForTransaction(hash, confirmations); }
+                wait: (confirmations?: number, timeout?: number) => this.provider.waitForTransaction(hash, confirmations, timeout),
             };
         });
     }


### PR DESCRIPTION
We have `timeout` as the second arg of `TransactionResponse.wait` property in runtime:
https://github.com/ethers-io/ethers.js/blob/master/packages/providers/src.ts/base-provider.ts#L1328

But it does not exist on its type declaration. This pull request adds that second arg to the type and updates the docs.