### PR TITLE
fix: return eth_chainId as hexadecimal

### DIFF
--- a/packages/experimental/src.ts/eip1193-bridge.ts
+++ b/packages/experimental/src.ts/eip1193-bridge.ts
@@ -59,7 +59,7 @@ export class Eip1193Bridge extends EventEmitter {
              }
              case "eth_chainId": {
                  const result = await this.provider.getNetwork();
-                 return result.chainId;
+                 return '0x' + result.chainId.toString(16);
              }
              case "eth_getBalance": {
                  const result = await this.provider.getBalance(params[0], params[1]);


### PR DESCRIPTION
An EIP1193 _must_ return chainId as a hexadecimal ([spec](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1193.md#:~:text=chainId%20MUST%20specify%20the%20integer%20ID%20of%20the%20connected%20chain%20as%20a%20hexadecimal%20string%2C%20per%20the%20eth_chainId%20Ethereum%20RPC%20method.)).

Updates `eth_chainId` calls on the `Eip1193Bridge` to convert the decimal chainId returned by `this.provider.getNetwork()` to a hexadecimal.