### PR TITLE
Allow BIP39 passphrase for Wallet

### DIFF
--- a/packages/hdnode/src.ts/index.ts
+++ b/packages/hdnode/src.ts/index.ts
@@ -70,6 +70,7 @@ export interface Mnemonic {
     readonly phrase: string;
     readonly path: string;
     readonly locale: string;
+    readonly passphrase?: string;
 };
 
 export class HDNode implements ExternallyOwnedAccount {
@@ -215,7 +216,8 @@ export class HDNode implements ExternallyOwnedAccount {
             mnemonicOrPath = Object.freeze({
                 phrase: srcMnemonic.phrase,
                 path: path,
-                locale: (srcMnemonic.locale || "en")
+                locale: (srcMnemonic.locale || "en"),
+                passphrase: (srcMnemonic.passphrase || "")
             });
         }
 
@@ -271,7 +273,8 @@ export class HDNode implements ExternallyOwnedAccount {
         return HDNode._fromSeed(mnemonicToSeed(mnemonic, password), {
             phrase: mnemonic,
             path: "m",
-            locale: wordlist.locale
+            locale: wordlist.locale,
+            passphrase: password
         });
     }
 

--- a/packages/wallet/src.ts/index.ts
+++ b/packages/wallet/src.ts/index.ts
@@ -57,11 +57,12 @@ export class Wallet extends Signer implements ExternallyOwnedAccount, TypedDataS
                     {
                         phrase: srcMnemonic.phrase,
                         path: srcMnemonic.path || defaultPath,
-                        locale: srcMnemonic.locale || "en"
+                        locale: srcMnemonic.locale || "en",
+                        passphrase: srcMnemonic.passphrase
                     }
                 ));
                 const mnemonic = this.mnemonic;
-                const node = HDNode.fromMnemonic(mnemonic.phrase, null, mnemonic.locale).derivePath(mnemonic.path);
+                const node = HDNode.fromMnemonic(mnemonic.phrase, mnemonic.passphrase, mnemonic.locale).derivePath(mnemonic.path);
                 if (computeAddress(node.privateKey) !== this.address) {
                     logger.throwArgumentError("mnemonic/address mismatch", "privateKey", "[REDACTED]");
                 }
@@ -176,7 +177,7 @@ export class Wallet extends Signer implements ExternallyOwnedAccount, TypedDataS
         }
 
         const mnemonic = entropyToMnemonic(entropy, options.locale);
-        return Wallet.fromMnemonic(mnemonic, options.path, options.locale);
+        return Wallet.fromMnemonic(mnemonic, options.path, options.locale, options.passphrase);
     }
 
     static fromEncryptedJson(json: string, password: Bytes | string, progressCallback?: ProgressCallback): Promise<Wallet> {
@@ -189,9 +190,9 @@ export class Wallet extends Signer implements ExternallyOwnedAccount, TypedDataS
         return new Wallet(decryptJsonWalletSync(json, password));
     }
 
-    static fromMnemonic(mnemonic: string, path?: string, wordlist?: Wordlist): Wallet {
+    static fromMnemonic(mnemonic: string, path?: string, wordlist?: Wordlist, password?: string): Wallet {
         if (!path) { path = defaultPath; }
-        return new Wallet(HDNode.fromMnemonic(mnemonic, null, wordlist).derivePath(path));
+        return new Wallet(HDNode.fromMnemonic(mnemonic, password, wordlist).derivePath(path));
     }
 }
 


### PR DESCRIPTION
I found that using HDNode.fromMnemonic() with a password and using the HDNode returned from result.derivePath() for a new Wallet would not work.

The goal of this PR is to avoid breaking any current usage of the library while adding the necessary functionality to make use of the passphrase in Wallet.

I added the passphrase in Mnemonic because it is associated with/only used with the mnemonic phrase. \[[BIP39](https://en.bitcoin.it/wiki/BIP_0039#From_mnemonic_to_seed)\]

All tests passed:

```
  Test Suite: Test HD Node Derivation is Case Agnostic (test-hdnode.js)
    Total Tests: 1409/1409 passed (0:18)  

  Test Suite: Test HD Node Derivation from Seed (test-hdnode.js)
    [ Still running suite - test # 791 ]
    Total Tests: 1049/1049 passed (0:40)  

  Test Suite: Test HD Node Derivation from Mnemonic (test-hdnode.js)
    [ Still running suite - test # 718 ]
    Total Tests: 1049/1049 passed (0:43)  

  Test Suite: Test HD Mnemonic Phrases (test-hdnode.js)
    Total Tests: 1409/1409 passed (0:03)  

  Test Suite: HD Extended Keys (test-hdnode.js)
    Total Tests: 2/2 passed (0:00)  

  Test Suite: HD error cases (test-hdnode.js)
    Total Tests: 7/7 passed (0:00)  

...(output truncated manually)

  Test Suite: Test JSON Wallets (test-wallet.js)
    [ Still running suite - test # 12 ]
    Total Tests: 12/12 passed (0:32)  

  Test Suite: Test Transaction Signing and Parsing (test-wallet.js)
    Total Tests: 2134/2134 passed (0:10)  

  Test Suite: Test Signing Messages (test-wallet.js)
    Total Tests: 9/9 passed (0:00)  

  Test Suite: Serialize Transactions (test-wallet.js)
    Total Tests: 1/1 passed (0:00)  

  Test Suite: Wallet Errors (test-wallet.js)
    Total Tests: 3/3 passed (0:00)  

  Test Suite: Check Wordlists (test-wordlists.js)
    Total Tests: 18/18 passed (0:00)  

  Total Tests: 27470/27470 passed (13:22)  

# status:0
```