### PR TITLE
Prevent defaulting referrer to "client" to fix TypeErrors

### DIFF
--- a/packages/web/src.ts/browser-geturl.ts
+++ b/packages/web/src.ts/browser-geturl.ts
@@ -20,7 +20,6 @@ export async function getUrl(href: string, options?: Options): Promise<GetUrlRes
         request.cache = <RequestCache>"no-cache";        // *default, no-cache, reload, force-cache, only-if-cached
         request.credentials = <RequestCredentials>"same-origin";  // include, *same-origin, omit
         request.redirect = <RequestRedirect>"follow";    // manual, *follow, error
-        request.referrer = "client";                     // no-referrer, *client
     };
 
     const response = await fetch(href, request);


### PR DESCRIPTION
The method `getUrl` tries to set some default headers before sending out the requests.
In case the option `skipFetchSetup` is set (it doesn't seem to be possible to unset it), the `referer` is defaulted to the string `client`. 

Given that this header expects a valid URL string, requests performed within certain contexts fail due to this issue.
For instance, running a query with a `JsonRpcProvider` inside a Cloudflare worker throws the following error:
` TypeError: Referrer "client" is not a valid URL.`

Full stack trace:

```
Error: missing response (requestBody="{\"method\":\"eth_blockNumber\",\"params\":[],\"id\":42,\"jsonrpc\":\"2.0\"}", requestMethod="POST", serverError={"cause":{"input":"client","code":"ERR_INVALID_URL"}}, url="https://rinkeby.infura.io/v3/<redacted>", code=SERVER_ERROR, version=web/5.5.1)
    at Logger.makeError (/<redacted>/dist/webpack:/worker-typescript-template/node_modules/@ethersproject/logger/lib.esm/index.js:185:1)
    at Logger.throwError (/<redacted>/dist/webpack:/worker-typescript-template/node_modules/@ethersproject/logger/lib.esm/index.js:194:1)
    at /<redacted>/dist/webpack:/worker-typescript-template/node_modules/@ethersproject/web/lib.esm/index.js:205:1
    at Generator.throw (<anonymous>)
    at rejected (/<redacted>/dist/webpack:/worker-typescript-template/node_modules/@ethersproject/web/lib.esm/index.js:6:1)
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  reason: 'missing response',
  code: 'SERVER_ERROR',
  requestBody: '{"method":"eth_blockNumber","params":[],"id":42,"jsonrpc":"2.0"}',
  requestMethod: 'POST',
  serverError: TypeError: Referrer "client" is not a valid URL.
      at new Request (/<redacted>/node_modules/undici/lib/fetch/request.js:230:25)
      at new Request (/<redacted>/node_modules/@miniflare/core/src/standards/http.ts:407:13)
      at upgradingFetch (/<redacted>/node_modules/@miniflare/web-sockets/src/fetch.ts:20:19)
      at WebSocketPlugin.<anonymous> (/<redacted>/node_modules/@miniflare/core/src/standards/http.ts:895:21)
      at fetch (/<redacted>/node_modules/@miniflare/web-sockets/src/plugin.ts:51:28)
      at /<redacted>/dist/webpack:/worker-typescript-template/node_modules/@ethersproject/web/lib.esm/geturl.js:30:1
      at Generator.next (<anonymous>)
      at /<redacted>/dist/webpack:/worker-typescript-template/node_modules/@ethersproject/web/lib.esm/geturl.js:8:1
      at new Promise (<anonymous>)
      at __awaiter (/<redacted>/dist/webpack:/worker-typescript-template/node_modules/@ethersproject/web/lib.esm/geturl.js:4:1) {
    cause: TypeError: Invalid URL
        at new NodeError (node:internal/errors:371:5)
        at onParseError (node:internal/url:552:9)
        at new URL (node:internal/url:628:5)
        at new Request (/<redacted>/node_modules/undici/lib/fetch/request.js:228:28)
        at new Request (/<redacted>/node_modules/@miniflare/core/src/standards/http.ts:407:13)
        at upgradingFetch (/<redacted>/node_modules/@miniflare/web-sockets/src/fetch.ts:20:19)
        at WebSocketPlugin.<anonymous> (/<redacted>/node_modules/@miniflare/core/src/standards/http.ts:895:21)
        at fetch (/<redacted>/node_modules/@miniflare/web-sockets/src/plugin.ts:51:28)
        at /<redacted>/dist/webpack:/worker-typescript-template/node_modules/@ethersproject/web/lib.esm/geturl.js:30:1
        at Generator.next (<anonymous>) {
      input: 'client',
      code: 'ERR_INVALID_URL'
    }
  },
  url: 'https://rinkeby.infura.io/v3/<redacted>'
}
```

Removing the referer completely fixes the issue.