### PR TITLE
Change abi.packEncoded to abi.encodePacked in docs

### DIFF
--- a/docs.wrm/api/utils/hashing.wrm
+++ b/docs.wrm/api/utils/hashing.wrm
@@ -326,7 +326,7 @@ TypedDataEncoder.hashDomain(domain)
 
 _subsection: Solidity Hashing Algorithms @<utils--solidity-hashing>
 
-When using the Solidity ``abi.packEncoded(...)`` function, a non-standard
+When using the Solidity ``abi.encodePacked(...)`` function, a non-standard
 //tightly packed// version of encoding is used. These functions implement
 the tightly packing algorithm.
 


### PR DESCRIPTION
This is the correct name as seen [in the Solidity docs](https://docs.soliditylang.org/en/v0.5.3/abi-spec.html#non-standard-packed-mode).