### PR TITLE
Fix the usage description of block.difficulty and block._difficulty in v5

### DIFF
--- a/docs/v5/api/providers/types/README.md
+++ b/docs/v5/api/providers/types/README.md
@@ -63,7 +63,7 @@ This property is generally of little interest to developers.
 
 #### *block* . **difficulty** => *null*
 
-Because the difficulty had reached the limit of IEEE754 numbers, this attribute is deprecated.
+Because the difficulty had reached the limit of IEEE754 numbers, this property is temporarily deprecated at v5. It will be available again at v6.
 
 
 #### *block* . **_difficulty** => *[BigNumber](/v5/api/utils/bignumber/)*

--- a/docs/v5/api/providers/types/README.md
+++ b/docs/v5/api/providers/types/README.md
@@ -61,7 +61,12 @@ The nonce used as part of the proof-of-work to mine this block.
 This property is generally of little interest to developers.
 
 
-#### *block* . **difficulty** => *number*
+#### *block* . **difficulty** => *null*
+
+Because the difficulty had reached the limit of IEEE754 numbers, this attribute is deprecated.
+
+
+#### *block* . **_difficulty** => *[BigNumber](/v5/api/utils/bignumber/)*
 
 The difficulty target required to be met by the miner of the block.
 

--- a/docs/v5/api/providers/types/index.html
+++ b/docs/v5/api/providers/types/index.html
@@ -55,7 +55,9 @@
 
 <p>This property is generally of little interest to developers.</p>
 
-</div></div><div class="property show-anchors"><div class="signature"><span class="path">block</span><span class="symbol">.</span><span class="method">difficulty</span> <span class="arrow">&rArr;</span> <span class="returns">number</span><div class="anchors"></div></div><div class="body"><p>The difficulty target required to be met by the miner of the block.</p>
+</div></div><div class="property show-anchors"><div class="signature"><span class="path">block</span><span class="symbol">.</span><span class="method">difficulty</span> <span class="arrow">&rArr;</span> <span class="returns">null</span><div class="anchors"></div></div><div class="body"><p>Because the difficulty had reached the limit of IEEE754 numbers, this attribute is deprecated.</p>
+
+</div></div><div class="property show-anchors"><div class="signature"><span class="path">block</span><span class="symbol">.</span><span class="method">_difficulty</span> <span class="arrow">&rArr;</span> <span class="returns"><a href="/v5/api/utils/bignumber/">BigNumber</a></span><div class="anchors"></div></div><div class="body"><p>The difficulty target required to be met by the miner of the block.</p>
 
 <p>This property is generally of little interest to developers.</p>
 

--- a/docs/v5/api/providers/types/index.html
+++ b/docs/v5/api/providers/types/index.html
@@ -55,7 +55,7 @@
 
 <p>This property is generally of little interest to developers.</p>
 
-</div></div><div class="property show-anchors"><div class="signature"><span class="path">block</span><span class="symbol">.</span><span class="method">difficulty</span> <span class="arrow">&rArr;</span> <span class="returns">null</span><div class="anchors"></div></div><div class="body"><p>Because the difficulty had reached the limit of IEEE754 numbers, this attribute is deprecated.</p>
+</div></div><div class="property show-anchors"><div class="signature"><span class="path">block</span><span class="symbol">.</span><span class="method">difficulty</span> <span class="arrow">&rArr;</span> <span class="returns">null</span><div class="anchors"></div></div><div class="body"><p>Because the difficulty had reached the limit of IEEE754 numbers, this property is temporarily deprecated at v5. It will be available again at v6.</p>
 
 </div></div><div class="property show-anchors"><div class="signature"><span class="path">block</span><span class="symbol">.</span><span class="method">_difficulty</span> <span class="arrow">&rArr;</span> <span class="returns"><a href="/v5/api/utils/bignumber/">BigNumber</a></span><div class="anchors"></div></div><div class="body"><p>The difficulty target required to be met by the miner of the block.</p>
 


### PR DESCRIPTION
According to #2001 & #2036, `block.difficulty` could give results that overflow IEEE754 number representation. Therefore, @ricmoo had fixed this issue, but it seems that the docs didn't updated yet.