### PR TITLE
Fix memory leak in `providers/_internalBlockNumber`

### DIFF
--- a/packages/providers/src.ts/base-provider.ts
+++ b/packages/providers/src.ts/base-provider.ts
@@ -879,7 +879,7 @@ export class BaseProvider extends Provider implements EnsProvider {
         if (maxAge > 0) {
 
             // While there are pending internal block requests...
-            while (this._internalBlockNumberQuery.promise) {
+            while (this._internalBlockNumberQuery && this._internalBlockNumberQuery.promise) {
 
                 // ..."remember" which fetch we started with
                 const startId = this._internalBlockNumberQuery.id;

--- a/packages/providers/src.ts/base-provider.ts
+++ b/packages/providers/src.ts/base-provider.ts
@@ -890,7 +890,9 @@ export class BaseProvider extends Provider implements EnsProvider {
                     if ((getTime() - result.respTime) <= maxAge) {
                         return result.blockNumber;
                     }
-                } catch { }
+                } catch (err) {
+                    logger.debug(`Failed 'eth_blockNumber' query.`, err)
+                 }
 
                 // The fetch rejected or had stale data, check if there
                 // was a new attempt, otherwise initiate a new one by


### PR DESCRIPTION
## TLDR

There is a memory leak in `_internalBlockNumber` which can be fixed using a primitive type instead of a Promise

## Current Situation

When using Ethers.js for a longer time to subscribe to events, i.e. when building an indexer, Ethers.js produces a significant drain of memory which causes the process to run out of memory after ~ a day.

An analysis with the heap analyzer has shown that the V8 process stores multiple copies of the `_internalBlockNumber` closures and thus unnecessarily pollutes the heap.

## The fix

It seems that 

```
if (this._internalBlockNumber === internalBlockNumber) {
  break;
}
```

leads V8 to store the entire closure created by the promise - and not just a "Promise id".

A possible fix is to introduce an explicit "promise id" by using a primitive type, i.e. number. The suggested fix does not change the functionality but significantly reduces the memory consumption.