### PR TITLE
Update WebSocketLike to accept null types

### DIFF
--- a/packages/providers/src.ts/websocket-provider.ts
+++ b/packages/providers/src.ts/websocket-provider.ts
@@ -40,13 +40,14 @@ export type Subscription = {
 };
 
 export interface WebSocketLike {
-    onopen: (...args: Array<any>) => any;
-    onmessage: (...args: Array<any>) => any;
-    onerror: (...args: Array<any>) => any;
+    onopen: ((...args: Array<any>) => any) | null;
+    onmessage: ((...args: Array<any>) => any) | null;
+    onerror: ((...args: Array<any>) => any) | null;
 
     readyState: number;
 
     send(payload: any): void;
+
     close(code?: number, reason?: string): void;
 }
 


### PR DESCRIPTION
This is to make the interface compatible with the popular npm package "reconnecting-websocket": https://github.com/pladaria/reconnecting-websocket/blob/05a2f7cb0e31f15dff5ff35ad53d07b1bec5e197/reconnecting-websocket.ts#L196-L212

This change makes sense for general purposes, because the callbacks are initially expected to be null before user assigns it manually.