### PR TITLE
fix: correctly handle V check for big chain IDs

### DIFF
--- a/packages/transactions/src.ts/index.ts
+++ b/packages/transactions/src.ts/index.ts
@@ -288,7 +288,7 @@ function _serialize(transaction: UnsignedTransaction, signature?: SignatureLike)
         v += chainId * 2 + 8;
 
         // If an EIP-155 v (directly or indirectly; maybe _vs) was provided, check it!
-        if (sig.v > 28 && sig.v !== v) {
+        if (sig.v > 28 && sig.v !== v % 256) {
              logger.throwArgumentError("transaction.chainId/signature.v mismatch", "signature", signature);
         }
     } else if (sig.v !== v) {


### PR DESCRIPTION
Fixes a bug in @ethersproject/transactions where certain valid signature
V parameters would be considered invalid when a sufficiently large chain
ID is used. Signature V parameter will always be just one byte, so has a
potential value of 0 to 255. Check in question would do the calculation
(sig.v ?== 27 + sig.recoveryParam + chainId * 2 + 8). When chainId is >=
111, the right-hand side of the formula will always be greater than 255
and therefore the check will always fail. Fix is to add a modulo 256 to
the right-hand side of the equation.

A quick note: causes signing with Ledger wallets on networks with big chain IDs to fail consistently. `ethers.Wallet` is not subject to this problem because it always returns a signature with a V parameter of 27 or 28 (considered a "maybe protected" signature). I believe either is technically fine. [Geth handles both cases](https://github.com/ethereum/go-ethereum/blob/40cfe710024ef90d8599c6fe2261cdcdabeeb0be/core/types/transaction.go#L201-L225).