### PR TITLE
Updated the pocket-provider to align with more recent updates

### DIFF
--- a/packages/providers/src.ts/pocket-provider.ts
+++ b/packages/providers/src.ts/pocket-provider.ts
@@ -10,47 +10,10 @@ const logger = new Logger(version);
 
 import { UrlJsonRpcProvider } from "./url-json-rpc-provider";
 
-// These are load-balancer-based application IDs
-const defaultApplicationIds: Record<string, string> = {
-    homestead: "6004bcd10040261633ade990",
-    ropsten: "6004bd4d0040261633ade991",
-    rinkeby: "6004bda20040261633ade994",
-    goerli: "6004bd860040261633ade992",
-};
 
 export class PocketProvider extends UrlJsonRpcProvider {
     readonly applicationId: string;
     readonly applicationSecretKey: string;
-    readonly loadBalancer: boolean;
-
-    constructor(network?: Networkish, apiKey?: any) {
-        // We need a bit of creativity in the constructor because
-        // Pocket uses different default API keys based on the network
-
-        if (apiKey == null) {
-            const n = getStatic<(network: Networkish) => Network>(new.target, "getNetwork")(network);
-            if (n) {
-                const applicationId = defaultApplicationIds[n.name];
-                if (applicationId) {
-                    apiKey = {
-                        applicationId: applicationId,
-                        loadBalancer: true
-                    };
-                }
-            }
-
-            // If there was any issue above, we don't know this network
-            if (apiKey == null) {
-                logger.throwError("unsupported network", Logger.errors.INVALID_ARGUMENT, {
-                    argument: "network",
-                    value: network
-                });
-            }
-
-        }
-
-        super(network, apiKey);
-    }
 
     static getApiKey(apiKey: any): any {
         // Most API Providers allow null to get the default configuration, but
@@ -61,9 +24,8 @@ export class PocketProvider extends UrlJsonRpcProvider {
             logger.throwArgumentError("PocketProvider.getApiKey does not support null apiKey", "apiKey", apiKey);
         }
 
-        const apiKeyObj: { applicationId: string, applicationSecretKey: string, loadBalancer: boolean } = {
+        const apiKeyObj: { applicationId: string, applicationSecretKey: string } = {
             applicationId: null,
-            loadBalancer: false,
             applicationSecretKey: null
         };
 
@@ -79,14 +41,12 @@ export class PocketProvider extends UrlJsonRpcProvider {
 
             apiKeyObj.applicationId = apiKey.applicationId;
             apiKeyObj.applicationSecretKey = apiKey.applicationSecretKey;
-            apiKeyObj.loadBalancer = !!apiKey.loadBalancer;
 
         } else if (apiKey.applicationId) {
             logger.assertArgument((typeof (apiKey.applicationId) === "string"),
                 "apiKey.applicationId must be a string", "apiKey.applicationId", apiKey.applicationId);
 
             apiKeyObj.applicationId = apiKey.applicationId;
-            apiKeyObj.loadBalancer = !!apiKey.loadBalancer;
 
         } else {
             logger.throwArgumentError("unsupported PocketProvider apiKey", "apiKey", apiKey);
@@ -110,6 +70,18 @@ export class PocketProvider extends UrlJsonRpcProvider {
             case "goerli":
                 host = "eth-goerli.gateway.pokt.network";
                 break;
+	    case "kovan":
+	    	host = "poa-kovan.gateway.pokt.network";
+	    	break;
+	    case "xdai":
+		host = "gnosischain-mainnet.gateway.pokt.network";
+	    	break;
+	    case "matic":
+	        host = "poly-mainnet.gateway.pokt.network";
+	    	break;
+	    case "bnb":
+	        host = "bsc-mainnet.gateway.pokt.network";
+		break;
             default:
                 logger.throwError("unsupported network", Logger.errors.INVALID_ARGUMENT, {
                     argument: "network",
@@ -117,12 +89,7 @@ export class PocketProvider extends UrlJsonRpcProvider {
                 });
         }
 
-        let url = null;
-        if (apiKey.loadBalancer) {
-            url = `https:/\/${ host }/v1/lb/${ apiKey.applicationId }`
-        } else {
-            url = `https:/\/${ host }/v1/${ apiKey.applicationId }`
-        }
+        const url = `https:/\/${ host }/v1/lb/${ apiKey.applicationId }`
 
         const connection: ConnectionInfo = { url };
 
@@ -139,6 +106,6 @@ export class PocketProvider extends UrlJsonRpcProvider {
     }
 
     isCommunityResource(): boolean {
-        return (this.applicationId === defaultApplicationIds[this.network.name]);
+        return false;
     }
 }


### PR DESCRIPTION
While the original pocket provider provided some really great work-arounds to how the Pocket Portal handled it's RPC service, a lot of those unique quirks have since changed, and pocket now provides a more consistent experience.

The big changes to how the Pocket Portal manages it's RPC are as follows:

1. Different networks can all now use the **same** API key and Secret Key, no need for separate keys for each network.
2. All endpoints are now load balanced, this is no longer conditional on the specific network.

Since the last update, Pocket Network now supports the following `ethers.js` supported networks:

- Kovan
- Gnosis (xDAI)
- Polygon (Matic)
- Binance Smart Chain (bnb)

As well as now supporting the following other likely future compatible networks:

- Avalanche
- DFKchain
- Fantom
- FUSE
- Harmony
- IoTeX
- OKExChain
- Solana

These will always be tracked live [here](https://docs.pokt.network/home/resources/references/supported-blockchains).

Additionally, Pocket Network provides public community RPC resources available for the following supported chains:

- homestead - https://eth-rpc.gateway.pokt.network
- Gnosis (xDAI) - https://xdai-rpc.gateway.pokt.network
- Polygon (Matic) - https://poly-rpc.gateway.pokt.network/
- Avalanche - https://avax-mainnet.gateway.pokt.network/v1/lb/605238bf6b986eea7cf36d5e/ext/bc/C/rpc
- Binance Smart Chain (bnb) - https://bsc-mainnet.gateway.pokt.network/v1/lb/6136201a7bad1500343e248d

As well as the following unsupported chains:

- Fuse - https://fuse-rpc.gateway.pokt.network/
- Harmony - https://harmony-0-rpc.gateway.pokt.network
- IoTeX - https://iotex-mainnet.gateway.pokt.network/v1/lb/6176f902e19001003499f492
- DFKchain - https://avax-dfk.gateway.pokt.network/v1/lb/6244818c00b9f0003ad1b619/ext/bc/q2aTwKuyzgs8pynF7UXBZCU7DejbZbZ6EUyHr3JQzYgwNPUPi/rpc
- Fantom - https://fantom-mainnet.gateway.pokt.network/v1/lb/6261a8a154c745003bcdb0f8

All of which will be available [here](https://docs.pokt.network/home/resources/public-rpc-endpoints)

I'm not sure if these above links constitute a community resource by the ethers definition, but unfortunately, the current means of identifying them is rather hodge-podge at the moment. I've currently left the `isCommunityResource()` method as false, but am happy to go back and figure out the logic for determining that if the above public RPCs do qualify as a community resource.