### PR TITLE
NonceManager: fix transaction count update when sending transaction

### DIFF
--- a/packages/experimental/src.ts/nonce-manager.ts
+++ b/packages/experimental/src.ts/nonce-manager.ts
@@ -63,7 +63,7 @@ export class NonceManager extends ethers.Signer {
             transaction.nonce = this.getTransactionCount("pending");
             this.incrementTransactionCount();
         } else {
-            this.setTransactionCount(transaction.nonce);
+            this.setTransactionCount(transaction.nonce + 1);
         }
 
         return this.signer.sendTransaction(transaction).then((tx) => {


### PR DESCRIPTION
This PR fixes an issue that leads to reused nonces in some cases. 

When passing a transaction with a defined nonce, the NonceManager uses that to set the transaction count, which leads to the same nonce being reused for the next transaction (if the nonce is `n`, there has been `n+1` transactions)