### PR TITLE
Only fire events that were triggered at future blocks

### DIFF
--- a/packages/providers/src.ts/base-provider.ts
+++ b/packages/providers/src.ts/base-provider.ts
@@ -1099,7 +1099,10 @@ export class BaseProvider extends Provider implements EnsProvider {
                                 this._emitted["b:" + log.blockHash] = log.blockNumber;
                                 this._emitted["t:" + log.transactionHash] = log.blockNumber;
 
-                                this.emit(filter, log);
+                                // don't emit events from old blocks
+                                if(event._lastBlockNumber >= blockNumber){
+                                    this.emit(filter, log);
+                                }
                             });
                         }).catch((error: Error) => {
                             this.emit("error", error);


### PR DESCRIPTION
Fixes #1096 #2310 #3069 #1504.

I'm not sure if this doesn't break any other workflows, but happy to modify the PR to accommodate other use cases. Also if I'm missing something obvious I'm happy to learn how to use this functionality in a way to avoid having to deal with unnecessary old events. I tried raising this issue in one of the linked GitHub issues, but got no reply, that's why I spent some time learning how events are implemented under the hood and came up with a fix.