### PR TITLE
Change etherscan's getHistory query sort to DESC

### DIFF
--- a/packages/providers/src.ts/etherscan-provider.ts
+++ b/packages/providers/src.ts/etherscan-provider.ts
@@ -426,7 +426,7 @@ export class EtherscanProvider extends BaseProvider{
             address: (await this.resolveName(addressOrName)),
             startblock: ((startBlock == null) ? 0: startBlock),
             endblock: ((endBlock == null) ? 99999999: endBlock),
-            sort: "asc"
+            sort: "desc"
         };
 
         const result = await this.fetch("account", params);


### PR DESCRIPTION
Currently, real pagination of "newest-first" data is cumbersome to implement. With this change, all the library's client would need to do is call the API once, get 10000 results, and then query the next page using block from the last transaction.

This could also be passed as a parameter to 'getHistory' method to retain backwards-compatibility, but I did not want to meddle with tests and usage of this method throughout the codebase (and documentation).