### PR TITLE
Enable passing a json object for wallet json.

### DIFF
--- a/packages/json-wallets/src.ts/crowdsale.ts
+++ b/packages/json-wallets/src.ts/crowdsale.ts
@@ -37,8 +37,8 @@ export class CrowdsaleAccount extends Description<_CrowdsaleAccount> implements 
 }
 
 // See: https://github.com/ethereum/pyethsaletool
-export function decrypt(json: string, password: Bytes | string): ExternallyOwnedAccount {
-    const data = JSON.parse(json);
+export function decrypt(json: string | object, password: Bytes | string): ExternallyOwnedAccount {
+    const data = typeof json === 'object' ? json : JSON.parse(json);
 
     password = getPassword(password);
 

--- a/packages/json-wallets/src.ts/index.ts
+++ b/packages/json-wallets/src.ts/index.ts
@@ -22,7 +22,7 @@ function decryptJsonWallet(json: string, password: Bytes | string, progressCallb
     return Promise.reject(new Error("invalid JSON wallet"));
 }
 
-function decryptJsonWalletSync(json: string, password: Bytes | string): ExternallyOwnedAccount {
+function decryptJsonWalletSync(json: string | object, password: Bytes | string): ExternallyOwnedAccount {
     if (isCrowdsaleWallet(json)) {
         return decryptCrowdsale(json, password)
     }

--- a/packages/json-wallets/src.ts/inspect.ts
+++ b/packages/json-wallets/src.ts/inspect.ts
@@ -3,19 +3,19 @@
 import { getAddress } from "@ethersproject/address";
 
 
-export function isCrowdsaleWallet(json: string): boolean {
+export function isCrowdsaleWallet(json: string | object): boolean {
     let data: any = null;
     try {
-        data = JSON.parse(json);
+        data = typeof json === 'object' ? json : JSON.parse(json);
     } catch (error) { return false; }
 
     return (data.encseed && data.ethaddr);
 }
 
-export function isKeystoreWallet(json: string): boolean {
+export function isKeystoreWallet(json: string | object): boolean {
     let data: any = null;
     try {
-        data = JSON.parse(json);
+        data = typeof json === 'object' ? json : JSON.parse(json);
     } catch (error) { return false; }
 
     if (!data.version || parseInt(data.version) !== data.version || parseInt(data.version) !== 3) {
@@ -30,16 +30,16 @@ export function isKeystoreWallet(json: string): boolean {
 //    return (isSecretStorageWallet(json) || isCrowdsaleWallet(json));
 //}
 
-export function getJsonWalletAddress(json: string): string {
+export function getJsonWalletAddress(json: string | object): string {
     if (isCrowdsaleWallet(json)) {
         try {
-            return getAddress(JSON.parse(json).ethaddr);
+            return getAddress(json.ethaddr ?? JSON.parse(json).ethaddr);
         } catch (error) { return null; }
     }
 
     if (isKeystoreWallet(json)) {
         try {
-            return getAddress(JSON.parse(json).address);
+            return getAddress(json.address ?? JSON.parse(json).address);
         } catch (error) { return null; }
     }
 

--- a/packages/json-wallets/src.ts/keystore.ts
+++ b/packages/json-wallets/src.ts/keystore.ts
@@ -209,15 +209,15 @@ function _computeKdfKey<T>(data: any, password: Bytes | string, pbkdf2Func: Pbkd
 }
 
 
-export function decryptSync(json: string, password: Bytes | string): KeystoreAccount {
-    const data = JSON.parse(json);
+export function decryptSync(json: string | object, password: Bytes | string): KeystoreAccount {
+    const data = typeof json === 'object' ? json : JSON.parse(json);
 
     const key = _computeKdfKey(data, password, pbkdf2Sync, scrypt.syncScrypt);
     return _getAccount(data, key);
 }
 
-export async function decrypt(json: string, password: Bytes | string, progressCallback?: ProgressCallback): Promise<KeystoreAccount> {
-    const data = JSON.parse(json);
+export async function decrypt(json: string | object, password: Bytes | string, progressCallback?: ProgressCallback): Promise<KeystoreAccount> {
+    const data = typeof json === 'object' ? json : JSON.parse(json);
 
     const key = await _computeKdfKey(data, password, pbkdf2, scrypt.scrypt, progressCallback);
     return _getAccount(data, key);


### PR DESCRIPTION
This fixes enabling passing a wallet `json object` not only a wallet encoded JSON string. Before the error implied there was a problem with the wallet even when there isn't one. We can skip the parsing when it is an object and do the associated wallet checks. This significantly improves the user experience and don't incorrect convey that the wallet is a `invalid JSON wallet` when it actually is.