### PR TITLE
Fix types for strict nulls

### DIFF
--- a/packages/abstract-provider/src.ts/index.ts
+++ b/packages/abstract-provider/src.ts/index.ts
@@ -241,7 +241,8 @@ export abstract class Provider implements OnceBlockable {
             })
         });
 
-        let maxFeePerGas = null, maxPriorityFeePerGas = null;
+        let maxFeePerGas: BigNumber | null = null;
+        let maxPriorityFeePerGas: BigNumber | null = null;
 
         if (block && block.baseFeePerGas) {
             // We may want to compute this more accurately in the future,


### PR DESCRIPTION
This PR fixes following errors caused by strict null checks and which i was unable to suppress with `"skipLibCheck": true` tsc option.

```
node_modules/@ethersproject/abstract-provider/src.ts/index.ts:246:13 - error TS2322: Type 'BigNumber' is not assignable to type 'null'.

246             maxPriorityFeePerGas = BigNumber.from("2500000000");
                ~~~~~~~~~~~~~~~~~~~~

node_modules/@ethersproject/abstract-provider/src.ts/index.ts:247:13 - error TS2322: Type 'BigNumber' is not assignable to type 'null'.

247             maxFeePerGas = block.baseFeePerGas.mul(2).add(maxPriorityFeePerGas);
                ~~~~~~~~~~~~

node_modules/@ethersproject/abstract-provider/src.ts/index.ts:247:59 - error TS2345: Argument of type 'null' is not assignable to parameter of type 'BigNumberish'.

247             maxFeePerGas = block.baseFeePerGas.mul(2).add(maxPriorityFeePerGas);
                                                              ~~~~~~~~~~~~~~~~~~~~
```