### PR TITLE
fix: Argument of type 'string' is not assignable to parameter of type 'never'.

### DIFF
--- a/packages/units/src.ts/index.ts
+++ b/packages/units/src.ts/index.ts
@@ -46,7 +46,7 @@ export function commify(value: string | number): string {
         suffix = suffix.substring(0, suffix.length - 1);
     }
 
-    const formatted = [];
+    const formatted:string[] = [];
     while (whole.length) {
         if (whole.length <= 3) {
             formatted.unshift(whole);


### PR DESCRIPTION
fix: Argument of type 'string' is not assignable to parameter of type 'never'.
![image](https://user-images.githubusercontent.com/23111262/180437114-98060af8-828e-44df-993a-15bd0b5b4ca6.png)
