### PR TITLE
feat: add Quicknode provider

### DIFF
--- a/packages/providers/src.ts/index.ts
+++ b/packages/providers/src.ts/index.ts
@@ -30,6 +30,7 @@ import { JsonRpcProvider, JsonRpcSigner } from "./json-rpc-provider";
 import { JsonRpcBatchProvider } from "./json-rpc-batch-provider";
 import { NodesmithProvider } from "./nodesmith-provider";
 import { PocketProvider } from "./pocket-provider";
+import { QuicknodeProvider, QuicknodeWebSocketProvider } from "./quicknode-provider";
 import { StaticJsonRpcProvider, UrlJsonRpcProvider } from "./url-json-rpc-provider";
 import { Web3Provider } from "./web3-provider";
 import { WebSocketProvider } from "./websocket-provider";
@@ -119,6 +120,8 @@ export {
     JsonRpcBatchProvider,
     NodesmithProvider,
     PocketProvider,
+    QuicknodeProvider,
+    QuicknodeWebSocketProvider,
     StaticJsonRpcProvider,
     Web3Provider,
     WebSocketProvider,

--- a/packages/providers/src.ts/quicknode-provider.ts
+++ b/packages/providers/src.ts/quicknode-provider.ts
@@ -1,0 +1,89 @@
+"use strict";
+
+import { Networkish } from "@ethersproject/networks";
+import { ConnectionInfo } from "@ethersproject/web";
+import { getStatic } from "@ethersproject/properties";
+
+import { WebSocketProvider } from "./websocket-provider";
+import { CommunityResourcable } from "./formatter";
+
+import { Logger } from "@ethersproject/logger";
+import { version } from "./_version";
+const logger = new Logger(version);
+
+import { JsonRpcSigner } from "./json-rpc-provider";
+import { StaticJsonRpcProvider } from "./url-json-rpc-provider";
+
+export class QuicknodeWebSocketProvider
+  extends WebSocketProvider
+  implements CommunityResourcable
+{
+  constructor(network?: Networkish, connectionUrl?: string) {
+    const provider = new QuicknodeProvider(network, connectionUrl);
+
+    const url = provider.connection.url.replace(/^http/i, "ws");
+
+    super(url, provider.network);
+  }
+
+  isCommunityResource(): boolean {
+    return false;
+  }
+}
+
+type getUrlFunc = (connectionUrl: string) => ConnectionInfo;
+
+export class QuicknodeProvider
+  extends StaticJsonRpcProvider
+  implements CommunityResourcable
+{
+  constructor(network?: Networkish, connectionUrl?: string) {
+    if (!connectionUrl) {
+      return logger.throwArgumentError(
+        "no connectionUrl provided",
+        "connectionUrl",
+        connectionUrl
+      );
+    }
+
+    const connection = getStatic<getUrlFunc>(
+      new.target,
+      "getUrl"
+    )(connectionUrl);
+
+    super(connection, network);
+  }
+
+  static getWebSocketProvider(
+    network: Networkish,
+    connectionUrl: string
+  ): QuicknodeWebSocketProvider {
+    return new QuicknodeWebSocketProvider(network, connectionUrl);
+  }
+
+  isCommunityResource(): boolean {
+    return false;
+  }
+
+  getSigner(): JsonRpcSigner {
+    return logger.throwError(
+      "API provider does not support signing",
+      Logger.errors.UNSUPPORTED_OPERATION,
+      { operation: "getSigner" }
+    );
+  }
+
+  listAccounts(): Promise<Array<string>> {
+    return Promise.resolve([]);
+  }
+
+  static getUrl(connectionUrl: string): ConnectionInfo {
+    return {
+      allowGzip: true,
+      url: connectionUrl,
+      throttleCallback: () => {
+        return Promise.resolve(true);
+      },
+    };
+  }
+}


### PR DESCRIPTION
Gm! We were adding [Quicknode](https://www.quicknode.com/docs/ethereum) as an RPC provider recently, it was different than adding other providers because Quicknode endpoints are customizable. 

So we had to create a `QuicknodeProvider` class that accepts connection url instead of an apiKey. Here is the use example: 

```
const quicknodeConnectionUrl = 'https://{YOUR_QUICKNODE_ENDPOINT}/{YOUR_QUICKNODE_API_KEY}/'
const provider = new QuicknodeProvider(network, quicknodeConnectionUrl)
```

I took [UrlJsonRpcProvider class](https://github.com/ethers-io/ethers.js/blob/ce8f1e4015c0f27bf178238770b1325136e3351a/packages/providers/src.ts/url-json-rpc-provider.ts#L50) as the base and rewrote it a bit.

I thought that this class might be helpful for others too and can be included in the library. 
If not, your feedback is welcome anyway, especially on class inheritance (was this a good idea to extend from [StaticJsonRpcProvider](https://github.com/ethers-io/ethers.js/blob/ce8f1e4015c0f27bf178238770b1325136e3351a/packages/providers/src.ts/url-json-rpc-provider.ts#L28)?) and methods overriding 🙂  