### PR TITLE
feat: improve utility of isAddress

### DIFF
--- a/docs.wrm/api/utils/address.wrm
+++ b/docs.wrm/api/utils/address.wrm
@@ -96,8 +96,8 @@ getIcapAddress("0x8ba1f109551bd432803012645ac136ddd64dba72");
 getIcapAddress("XE65GB6LDNXYOFTX0NSV3FUWKOWIXAMJK36");
 //_log:
 
-_property: ethers.utils.isAddress(address) => boolean  @<utils-isAddress> @SRC<address>
-Returns true if //address// is valid (in any supported format).
+_property: ethers.utils.isAddress(address) => string<[[address]]> | false @<utils-isAddress> @SRC<address>
+Returns //address// as a Checksum Address if //address// is valid (in any supported format), else returns //false//.
 
 _code: @lang<javascript>
 

--- a/packages/address/src.ts/index.ts
+++ b/packages/address/src.ts/index.ts
@@ -112,11 +112,12 @@ export function getAddress(address: string): string {
     return result;
 }
 
-export function isAddress(address: string): boolean {
-    try {
-        getAddress(address);
-        return true;
-    } catch (error) { }
+export function isAddress(address: unknown): string | false {
+    if (typeof address === 'string') {
+        try {
+            return getAddress(address);
+        } catch (error) { }
+    }
     return false;
 }
 


### PR DESCRIPTION
Improves the utility of `isAddress`:
- allows it to check any type (`unknown`), instead of restricting it to `string`
- returns `string | false`, so that an `unknown` type passed in can then be narrowed to a `string` without coercion

This will not break usages in conditionals, as `string` is truthy, so `string | false` can still be used eg in `if (isAddress(addr))`.
This _will_ break usages where `true`/`false` are explicitly checked, such as `isAddress(addr) === true`/`!== false`.