### PR TITLE
Reverts: Do not run out of stack and extrac string reasons

### DIFF
--- a/packages/providers/src.ts/json-rpc-provider.ts
+++ b/packages/providers/src.ts/json-rpc-provider.ts
@@ -36,6 +36,21 @@ function spelunk(value: any, requireData: boolean): null | { message: string, da
     // Spelunk further...
     if (typeof(value) === "object") {
         for (const key in value) {
+            if (value instanceof Error && key === "stackTrace") {
+                /*
+                 * When an Error object is precessed, `stackTrace` property will
+                 * contain references to objects that represent files and
+                 * functions and is an internally cyclical data structure.
+                 * `spelunk` will loop though it until it will exceed all the
+                 * stack space.
+                 *
+                 * In any case, `stackTrace` does not contain an explanation as
+                 * to why the transaction was reverted, so it does not make
+                 * sense to look in there regardless of if it is cyclical or
+                 * not.
+                 */
+                continue;
+            }
             const result = spelunk(value[key], requireData);
             if (result) { return result; }
         }


### PR DESCRIPTION
This PR should help address https://github.com/ethers-io/ethers.js/discussions/2849, but it might not be enough to fully get us there.
```typescript
    await expect(contract.call()).to.revertedWith("revert message");
```
still does not really work for me.  I see:

```
     AssertionError: Expected transaction to be reverted with revert message, but other exception was thrown: Error: call revert exception [ See: https://links.ethers.org/v5-errors-CALL_EXCEPTION ] (method="call()", data="0xdeadbeef", errorArgs=null, errorName=null, errorSignature=null, reason=null, code=CALL_EXCEPTION, version=abi/5.7.0)
```

But it still seems a step in the right direction as it fixes a stack overflow, as well as actually extracts the right error message from the transaction execution result.