### PR TITLE
fix(infura | arbitrum-goerli): add support for arbitrum-goerli to infuraprovider

### DIFF
--- a/packages/providers/src.ts/infura-provider.ts
+++ b/packages/providers/src.ts/infura-provider.ts
@@ -117,6 +117,9 @@ export class InfuraProvider extends UrlJsonRpcProvider {
             case "arbitrum-rinkeby":
                 host = "arbitrum-rinkeby.infura.io";
                 break;
+            case "arbitrum-goerli":
+                host = "arbitrum-goerli.infura.io";
+                break;
             default:
                 logger.throwError("unsupported network", Logger.errors.INVALID_ARGUMENT, {
                     argument: "network",


### PR DESCRIPTION
# Description

When attempting to instantiate a new `providers.InfuraProvider` instance using the `arbitrum-goerli` chain id (421613), as such:

```ts
import { providers } from 'ethers'

const provider = new providers.InfuraProvider(421613, 'key')
```
throws the `unsupported network` error.

arbitrum goerli is now supported by infura.