### PR TITLE
Update base64.js

### DIFF
--- a/packages/base64/lib.esm/base64.js
+++ b/packages/base64/lib.esm/base64.js
@@ -1,7 +1,8 @@
 "use strict";
 import { arrayify } from "@ethersproject/bytes";
+import { Buffer } from "buffer";
 export function decode(textData) {
-    textData = atob(textData);
+    textData = Buffer.from(textData, 'base64').toString('binary');
     const data = [];
     for (let i = 0; i < textData.length; i++) {
         data.push(textData.charCodeAt(i));
@@ -14,6 +15,7 @@ export function encode(data) {
     for (let i = 0; i < data.length; i++) {
         textData += String.fromCharCode(data[i]);
     }
-    return btoa(textData);
+    let returnData = Buffer.from(textData, 'binary').toString('base64');
+    return returnData;
 }
 //# sourceMappingURL=base64.js.map


### PR DESCRIPTION
Removed atob() and btoa() as they have been depreciated.
Replaced them with equivalents that work
https://dirask.com/posts/Node-js-atob-btoa-functions-equivalents-1Aqb51