### PR TITLE
Throw errors from JsonRpcBatchProvider if result is not an array

### DIFF
--- a/packages/providers/src.ts/json-rpc-batch-provider.ts
+++ b/packages/providers/src.ts/json-rpc-batch-provider.ts
@@ -62,6 +62,18 @@ export class JsonRpcBatchProvider extends JsonRpcProvider {
                         provider: this
                     });
 
+                    if (!Array.isArray(result)) {
+                        if (result.error) {
+                            const error = new Error(result.error.message);
+                            (<any>error).code = result.error.code;
+                            (<any>error).data = result.error.data;
+                            throw error;
+                        }
+                        else {
+                            throw new Error("Batch result is not an array");
+                        }
+                    }
+
                     // For each result, feed it to the correct Promise, depending
                     // on whether it was a success or error
                     batch.forEach((inflightRequest, index) => {
@@ -76,7 +88,7 @@ export class JsonRpcBatchProvider extends JsonRpcProvider {
                         }
                     });
 
-                }, (error) => {
+                }).catch(error => {
                     this.emit("debug", {
                         action: "response",
                         error: error,


### PR DESCRIPTION
Batch rpc requests can return a non-array result if the batch as a whole fails.

This fix:
- Throws an Error (with message when available) if the response is not an array
- Swaps `.then(successFn, errorFn)` to `.then(successFn).catch(errorFn)` to ensure any errors thrown inside `successFn` are handled

Previously `const payload = result[index];` would throw and not be caught, causing the process to exit.

Fixes https://github.com/ethers-io/ethers.js/issues/2749#issuecomment-1268638214