### PR TITLE
deleted deprecated testnets, added Alchemy Goerli

### DIFF
--- a/docs.wrm/api/providers/api-providers.wrm
+++ b/docs.wrm/api/providers/api-providers.wrm
@@ -40,10 +40,7 @@ It is highly recommended for production, you register with
 _definition: **Supported Networks**
 
 - ``homestead`` - Homestead (Mainnet)
-- ``ropsten`` - Ropsten (proof-of-work testnet)
-- ``rinkeby`` - Rinkeby (proof-of-authority testnet)
 - ``goerli`` - G&ouml;rli (clique testnet)
-- ``kovan`` - Kovan (proof-of-authority testnet)
 
 _code: Etherscan Examples @lang<javascript>
 
@@ -54,10 +51,10 @@ _code: Etherscan Examples @lang<javascript>
 provider = new EtherscanProvider();
 
 // Connect to rinkeby testnet (these are equivalent)
-provider = new EtherscanProvider("rinkeby");
+provider = new EtherscanProvider("goerli");
 provider = new EtherscanProvider(4);
 
-network = ethers.providers.getNetwork("rinkeby");
+network = ethers.providers.getNetwork("goerli");
 //_hide: delete network._defaultProvider;
 //_log: network
 
@@ -107,16 +104,12 @@ It is highly recommended for production, you register with
 _definition: **Supported Networks**
 
 - ``homestead`` - Homestead (Mainnet)
-- ``ropsten`` - Ropsten (proof-of-work testnet)
-- ``rinkeby`` - Rinkeby (proof-of-authority testnet)
 - ``goerli`` - G&ouml;rli (clique testnet)
 - ``kovan`` - Kovan (proof-of-authority testnet)
 - ``matic`` - Polygon
 - ``maticmum`` - Polygon Mumbai Testnet
 - ``optimism`` - Optimism (L2; optimistic roll-up)
-- ``optimism-kovan`` - Optimism Testnet (L2; optimistic roll-up testnet)
 - ``arbitrum`` - Arbitrum (L2; optimistic roll-up)
-- ``arbitrum-rinkeby`` - Arbitrum Testnet (L2; optimistic roll-up testnet)
 
 _code: INFURA Examples @lang<javascript>
 
@@ -168,16 +161,11 @@ It is highly recommended for production, you register with
 _definition: **Supported Networks**
 
 - ``homestead`` - Homestead (Mainnet)
-- ``ropsten`` - Ropsten (proof-of-work testnet)
-- ``rinkeby`` - Rinkeby (proof-of-authority testnet)
 - ``goerli`` - G&ouml;rli (clique testnet)
-- ``kovan`` - Kovan (proof-of-authority testnet)
 - ``matic`` - Polygon
 - ``maticmum`` - Polygon Mumbai Testnet
 - ``optimism`` - Optimism (L2; optimistic roll-up)
-- ``optimism-kovan`` - Optimism Testnet (L2; optimistic roll-up testnet)
 - ``arbitrum`` - Arbitrum (L2; optimistic roll-up)
-- ``arbitrum-rinkeby`` - Arbitrum Testnet (L2; optimistic roll-up testnet)
 
 _code: Alchemy Examples @lang<javascript>
 
@@ -189,7 +177,7 @@ provider = new AlchemyProvider();
 
 // Connect to the ropsten testnet
 // (see EtherscanProvider above for other network examples)
-provider = new AlchemyProvider("ropsten");
+provider = new AlchemyProvider("goerli");
 
 // Connect to mainnet with an API key (these are equivalent)
 provider = new AlchemyProvider(null, apiKey);
@@ -241,8 +229,6 @@ It is highly recommended for production, you register with
 _definition: **Supported Networks**
 
 - ``homestead`` - Homestead (Mainnet)
-- ``ropsten`` - Ropsten (proof-of-work testnet)
-- ``rinkeby`` - Rinkeby (proof-of-authority testnet)
 - ``goerli`` - G&ouml;rli (clique testnet)
 
 _code: Pocket Examples @lang<javascript>

--- a/docs.wrm/api/providers/index.wrm
+++ b/docs.wrm/api/providers/index.wrm
@@ -78,7 +78,7 @@ There are several official common Ethereum networks as well as custom
 networks and other compatible projects.
 
 Any API that accept a [[providers-Networkish]] can be passed a common
-name (such as ``"mainnet"`` or ``"ropsten"``) or chain ID to use that
+name (such as ``"mainnet"`` or ``"goerli"``) or chain ID to use that
 network definition or may specify custom parameters.
 
 _property: ethers.providers.getNetwork(aNetworkish) => [[providers-Network]]


### PR DESCRIPTION
Hey Ric Moo!

I am John, and I’m an ambassador for Alchemy. Love how Ethers.io is providing a scalable library for Web3 developers - kudos.👏👏

Noticed you referenced Rinkeby and Ropsten, and Kovan, which are now deprecated due to the Ethereum Merge, in your documentation.

As you probably know, Goerli is now the main testnet.

If helpful, I’m linking Alchemy’s goerli faucet (anyone can get 0.5 Goerli testnet ETH free per day) here - https://goerlifaucet.com/.

Also in case it’s useful to your readers, here’s some good dev docs - https://www.alchemy.com/overviews/migrate-from-rinkeby-to-goerli https://www.alchemy.com/overviews/migrate-from-ropsten-to-goerli

Let us know if Alchemy can ever be helpful, and keep up the awesome content!

=
John.