### PR TITLE
Update Infura provider to support Arbitrum Goerli

### DIFF
--- a/packages/providers/src.ts/infura-provider.ts
+++ b/packages/providers/src.ts/infura-provider.ts
@@ -120,6 +120,9 @@ export class InfuraProvider extends UrlJsonRpcProvider {
             case "arbitrum-rinkeby":
                 host = "arbitrum-rinkeby.infura.io";
                 break;
+            case "arbitrum-goerli":
+                host = "arbitrum-goerli.infura.io";
+                break;    
             default:
                 logger.throwError("unsupported network", Logger.errors.INVALID_ARGUMENT, {
                     argument: "network",


### PR DESCRIPTION
Since Arbitrum's Testnet for Rinkeby has been marked as read-only as of October 5th, we now need to support Arbitrum's new Goerli based testnet. This PR addresses that.