### PR TITLE
Allow passing string as wordlist to `Wallet.fromMnemonic`

### DIFF
--- a/packages/wallet/src.ts/index.ts
+++ b/packages/wallet/src.ts/index.ts
@@ -187,7 +187,7 @@ export class Wallet extends Signer implements ExternallyOwnedAccount, TypedDataS
         return new Wallet(decryptJsonWalletSync(json, password));
     }
 
-    static fromMnemonic(mnemonic: string, path?: string, wordlist?: Wordlist): Wallet {
+    static fromMnemonic(mnemonic: string, path?: string, wordlist?: Wordlist | string): Wallet {
         if (!path) { path = defaultPath; }
         return new Wallet(HDNode.fromMnemonic(mnemonic, null, wordlist).derivePath(path));
     }


### PR DESCRIPTION
Allow passing string as wordlist to `Wallet.fromMnemonic`, same as underlying `HDNode` call allows. Otherwise (valid and correct on runtime) code fails:

```ts
const account = ethersWallet.fromMnemonic(mnemonic, path, 'en');
```