### PR TITLE
Add timeout to .wait() type definition

### DIFF
--- a/packages/abstract-provider/lib/index.d.ts
+++ b/packages/abstract-provider/lib/index.d.ts
@@ -28,7 +28,7 @@ export interface TransactionResponse extends Transaction {
     confirmations: number;
     from: string;
     raw?: string;
-    wait: (confirmations?: number) => Promise<TransactionReceipt>;
+    wait: (confirmations?: number, timeout?: number) => Promise<TransactionReceipt>;
 }
 export declare type BlockTag = string | number;
 export interface _Block {


### PR DESCRIPTION
Hello! The `wait` function in `base-provider` does not contain the `timeout` argument in the type definition file. I need this in my project and would love to avoid `// @ts-ignore`. 😅 Thank you!

From ethers.js:
<img width="464" alt="Snag_2ed233c" src="https://user-images.githubusercontent.com/224192/197228883-e299b137-acdf-4dec-93b1-fcafc5024408.png">
