### PR TITLE
fix: alchemy provider url handling

### DIFF
--- a/packages/providers/lib.esm/alchemy-provider.js
+++ b/packages/providers/lib.esm/alchemy-provider.js
@@ -14,8 +14,7 @@ const defaultApiKey = "_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC";
 export class AlchemyWebSocketProvider extends WebSocketProvider {
     constructor(network, apiKey) {
         const provider = new AlchemyProvider(network, apiKey);
-        const url = provider.connection.url.replace(/^http/i, "ws")
-            .replace(".alchemyapi.", ".ws.alchemyapi.");
+        const url = provider.connection.url.replace(/^http/i, "ws");
         super(url, provider.network);
         defineReadOnly(this, "apiKey", provider.apiKey);
     }
@@ -40,7 +39,7 @@ export class AlchemyProvider extends UrlJsonRpcProvider {
         let host = null;
         switch (network.name) {
             case "homestead":
-                host = "eth-mainnet.alchemyapi.io/v2/";
+                host = "eth-mainnet.g.alchemy.com/v2/";
                 break;
             case "ropsten":
                 host = "eth-ropsten.alchemyapi.io/v2/";

--- a/packages/providers/lib/alchemy-provider.js
+++ b/packages/providers/lib/alchemy-provider.js
@@ -33,8 +33,7 @@ var AlchemyWebSocketProvider = /** @class */ (function (_super) {
     function AlchemyWebSocketProvider(network, apiKey) {
         var _this = this;
         var provider = new AlchemyProvider(network, apiKey);
-        var url = provider.connection.url.replace(/^http/i, "ws")
-            .replace(".alchemyapi.", ".ws.alchemyapi.");
+        var url = provider.connection.url.replace(/^http/i, "ws");
         _this = _super.call(this, url, provider.network) || this;
         (0, properties_1.defineReadOnly)(_this, "apiKey", provider.apiKey);
         return _this;
@@ -66,7 +65,7 @@ var AlchemyProvider = /** @class */ (function (_super) {
         var host = null;
         switch (network.name) {
             case "homestead":
-                host = "eth-mainnet.alchemyapi.io/v2/";
+                host = "eth-mainnet.g.alchemy.com/v2/";
                 break;
             case "ropsten":
                 host = "eth-ropsten.alchemyapi.io/v2/";

--- a/packages/providers/src.ts/alchemy-provider.ts
+++ b/packages/providers/src.ts/alchemy-provider.ts
@@ -26,8 +26,7 @@ export class AlchemyWebSocketProvider extends WebSocketProvider implements Commu
     constructor(network?: Networkish, apiKey?: any) {
         const provider = new AlchemyProvider(network, apiKey);
 
-        const url = provider.connection.url.replace(/^http/i, "ws")
-                                           .replace(".alchemyapi.", ".ws.alchemyapi.");
+        const url = provider.connection.url.replace(/^http/i, "ws");
 
         super(url, provider.network);
         defineReadOnly(this, "apiKey", provider.apiKey);
@@ -56,7 +55,7 @@ export class AlchemyProvider extends UrlJsonRpcProvider {
         let host = null;
         switch (network.name) {
             case "homestead":
-                host = "eth-mainnet.alchemyapi.io/v2/";
+                host = "eth-mainnet.g.alchemy.com/v2/";
                 break;
             case "ropsten":
                 host = "eth-ropsten.alchemyapi.io/v2/";


### PR DESCRIPTION
Hey @ricmoo , Recently the provider started to fail with this error:
`Error: could not detect network (event="noNetwork", code=NETWORK_ERROR, version=providers/5.5.3)`
same thing for latest version.
See this:
https://github.com/rainbow-me/rainbowkit/issues/843
https://github.com/ethers-io/ethers.js/discussions/1928

Changing this in my code:
```
  webSocketProvider({ chainId }) {
    return new providers.AlchemyWebSocketProvider(
      isChainSupported(chainId) ? chainId : defaultChain.id,
      API_KEY,
    );
  },
```
```
  webSocketProvider() {
    return new providers.WebSocketProvider(
      "wss://eth-mainnet.g.alchemy.com/v2/API_KEY",
    );
  },
```
Has fixed the issue, so I guess the logic in the following files should be updated ASAP ;)

Let me know what you think.