### PR TITLE
fix(types): restricts locale to existing wordlists

### DIFF
--- a/packages/wordlists/src.ts/wordlists.ts
+++ b/packages/wordlists/src.ts/wordlists.ts
@@ -1,15 +1,13 @@
-import { Wordlist } from "./wordlist";
-
 import { langCz as cz } from "./lang-cz";
 import { langEn as en } from "./lang-en";
 import { langEs as es } from "./lang-es";
 import { langFr as fr } from "./lang-fr";
+import { langIt as it } from "./lang-it";
 import { langJa as ja } from "./lang-ja";
 import { langKo as ko } from "./lang-ko";
-import { langIt as it } from "./lang-it";
 import { langZhCn as zh_cn, langZhTw as zh_tw } from "./lang-zh";
 
-export const wordlists: { [ locale: string ]: Wordlist } = {
+export const wordlists = {
     cz: cz,
     en: en,
     es: es,
@@ -20,6 +18,6 @@ export const wordlists: { [ locale: string ]: Wordlist } = {
     zh: zh_cn,
     zh_cn: zh_cn,
     zh_tw: zh_tw
-};
+} as const;
 
-
+export type Locale = keyof typeof wordlists;


### PR DESCRIPTION
When using the wordlist as library it would be helpful to have typescript check that a wordlist exists in a given language.