### PR TITLE
docs(experimental): Eip1193Bridge typo

### DIFF
--- a/packages/experimental/README.md
+++ b/packages/experimental/README.md
@@ -69,7 +69,7 @@ import { Eip1193Bridge } from "@ethersproject/experimental/retry-provider";
 const signer = "... any way you get an ethers Signer...";
 const provider = "... any way you get an ethers Provider...";
 
-const eip1193Provider = new Eip1193Provider(signer, provider);
+const eip1193Provider = new Eip1193Bridge(signer, provider);
 
 ```
 


### PR DESCRIPTION
There is a typo in the documentation of the experimental package.

It uses a class under the naming `Eip1193Provider` while actually, it's `Eip1193Bridge`