### PR TITLE
Replaces NodeJS specific type with type that works in node and browser.

### DIFF
--- a/packages/providers/src.ts/base-provider.ts
+++ b/packages/providers/src.ts/base-provider.ts
@@ -720,8 +720,8 @@ export class BaseProvider extends Provider implements EnsProvider {
     _emitted: { [ eventName: string ]: number | "pending" };
 
     _pollingInterval: number;
-    _poller: NodeJS.Timer;
-    _bootstrapPoll: NodeJS.Timer;
+    _poller: ReturnType<typeof setTimeout>;
+    _bootstrapPoll: ReturnType<typeof setTimeout>;
 
     _lastBlockNumber: number;
     _maxFilterBlockRange: number;


### PR DESCRIPTION
`NodeJS.Timer` results in a dependency on `@types/node`.  If a web project adds this, then they will incorrectly be allowed to do things like `require(...)` and `process.exit(...)` and `process.env` without a compiler error.

This change makes it so the type of the variable matches whatever the return type of `setTimeout` is in the current compiler target environment, which I believe is `number` in browser and `NodeJS.Timer` in node.