### PR TITLE
v6: Replaces NodeJS specific type with type that works in node and browser.

### DIFF
--- a/src.ts/providers/provider-jsonrpc.ts
+++ b/src.ts/providers/provider-jsonrpc.ts
@@ -357,7 +357,7 @@ export class JsonRpcApiProvider extends AbstractProvider {
 
     // Payloads are queued and triggered in batches using the drainTimer
     #payloads: Array<Payload>;
-    #drainTimer: null | NodeJS.Timer;
+    #drainTimer: null | ReturnType<typeof setTimeout>;
 
     #notReady: null | {
         promise: Promise<void>,


### PR DESCRIPTION
`NodeJS.Timer` results in a dependency on `@types/node`.  If a web project adds this, then they will incorrectly be allowed to do things like `require(...)` and `process.exit(...)` and `process.env` without a compiler error.

This change makes it so the type of the variable matches whatever the return type of `setTimeout` is in the current compiler target environment, which I believe is `number` in browser and `NodeJS.Timer` in node.