### PR TITLE
error handling on all zero data

### DIFF
--- a/packages/ethers/dist/ethers.esm.js
+++ b/packages/ethers/dist/ethers.esm.js
@@ -7722,6 +7722,9 @@ function parseBytes32String(bytes) {
     let length = 31;
     while (data[length - 1] === 0) {
         length--;
+        if(length <= 0) {
+            throw new Error("invalid bytes32 string - no null terminator");
+        }
     }
     // Determine the string value
     return toUtf8String(data.slice(0, length));

--- a/packages/strings/lib/bytes32.js
+++ b/packages/strings/lib/bytes32.js
@@ -28,6 +28,9 @@ function parseBytes32String(bytes) {
     var length = 31;
     while (data[length - 1] === 0) {
         length--;
+        if(length <= 0) {
+            throw new Error("invalid bytes32 string - no null terminator");
+        }
     }
     // Determine the string value
     return (0, utf8_1.toUtf8String)(data.slice(0, length));

--- a/packages/strings/src.ts/bytes32.ts
+++ b/packages/strings/src.ts/bytes32.ts
@@ -27,7 +27,11 @@ export function parseBytes32String(bytes: BytesLike): string {
 
     // Find the null termination
     let length = 31;
-    while (data[length - 1] === 0) { length--; }
+    while (data[length - 1] === 0) { length--;
+        if(length <= 0) {
+            throw new Error("invalid bytes32 string - no null terminator");
+        } 
+    }
 
     // Determine the string value
     return toUtf8String(data.slice(0, length));


### PR DESCRIPTION
Currently parseBytes32String throws error of invalid array length when  length reaches 0.

Added error handling to throw appropriate error.