### PR TITLE
Improvement: strict address validation for Contract constructor

### DIFF
--- a/packages/contracts/src.ts/index.ts
+++ b/packages/contracts/src.ts/index.ts
@@ -11,6 +11,7 @@ import { AccessList, accessListify, AccessListish } from "@ethersproject/transac
 
 import { Logger } from "@ethersproject/logger";
 import { version } from "./_version";
+import { ethers } from "ethers";
 
 const logger = new Logger(version);
 
@@ -708,7 +709,7 @@ export class BaseContract {
         defineReadOnly(this, "_runningEvents", { });
         defineReadOnly(this, "_wrappedEmits", { });
 
-        if (addressOrName == null) {
+        if (!ethers.utils.isAddress(addressOrName)) {
             logger.throwArgumentError("invalid contract address or ENS name", "addressOrName", addressOrName);
         }
 


### PR DESCRIPTION
If invalid address was provided an error will occur later in app lifecycle when trying to interact with a contract providing a misleading info.