### PR TITLE
Optimized strings prefix judge: use startsWith instead of substring

### DIFF
--- a/misc/admin/src.ts/cmds/bump-minor-version.ts
+++ b/misc/admin/src.ts/cmds/bump-minor-version.ts
@@ -27,7 +27,7 @@ import { dirnames, getPackageJsonPath } from "../path";
                 }
             } else {
                 if (prefix === "ethers" || prefix === "@ethersproject") {
-                    if (version.substring(0, 1) !== "^") {
+                    if (!version.startsWith("^")) {
                         throw new Error(`bad version for bumping: ${ dirname }:${ name }:${ version }`);
                     }
                     version = "^" + newVersion;

--- a/misc/admin/src.ts/cmds/spell-check.ts
+++ b/misc/admin/src.ts/cmds/spell-check.ts
@@ -180,17 +180,13 @@ function checkWord(word: string): boolean {
     return false;
 }
 
-function starts(text: string, prefix: string): boolean {
-    return (text.substring(0, prefix.length) === prefix);
-}
-
 (async function() {
     console.log(colorify.bold("Spell checking source code strings..."));
 
     let count = 0;
     getAllStrings(resolve(__dirname, "../../../../packages")).forEach((file: Foo) => {
-        if (starts(file.filename, "/testcases/src.ts/generation-scripts")) { return; }
-        if (starts(file.filename, "/asm/src.ts/opcodes.ts")) { return; }
+        if (file.filename.startsWith("/testcases/src.ts/generation-scripts")) { return; }
+        if (file.filename.startsWith("/asm/src.ts/opcodes.ts")) { return; }
 
         file.values.forEach((entry) => {
             function problem(word: string): void {
@@ -210,7 +206,7 @@ function starts(text: string, prefix: string): boolean {
 
             // Prolly a require
             if (value.match(/^@ethersproject\/[a-z0-9-]+$/)) { return; }
-            if (value.substring(0, 2) === "./") { return; }
+            if (value.startsWith("./")) { return; }
 
             // Prolly encoded binary data
             if (value.indexOf(" ") === -1 && value.length > 20) { return; }

--- a/packages/address/src.ts/index.ts
+++ b/packages/address/src.ts/index.ts
@@ -84,7 +84,7 @@ export function getAddress(address: string): string {
     if (address.match(/^(0x)?[0-9a-fA-F]{40}$/)) {
 
         // Missing the 0x prefix
-        if (address.substring(0, 2) !== "0x") { address = "0x" + address; }
+        if (!address.startsWith("0x")) { address = "0x" + address; }
 
         result = getChecksumAddress(address);
 

--- a/packages/asm/src.ts/assembler.ts
+++ b/packages/asm/src.ts/assembler.ts
@@ -245,7 +245,7 @@ export class LiteralNode extends ValueNode {
     async assemble(assembler: Assembler, visit: AssembleVisitFunc): Promise<void> {
         assembler.start(this);
         if (this.verbatim) {
-            if (this.value.substring(0, 2) === "0x") {
+            if (this.value.startsWith("0x")) {
                 visit(this, this.value);
             } else {
                 visit(this, ethers.BigNumber.from(this.value).toHexString());

--- a/packages/asm/src.ts/opcodes.ts
+++ b/packages/asm/src.ts/opcodes.ts
@@ -46,7 +46,7 @@ export class Opcode {
 
     // Returns the number of of bytes this performs if a PUSH; 0 otherwise
     isPush(): number {
-        if (this.mnemonic.substring(0, 4) === "PUSH") {
+        if (this.mnemonic.startsWith("PUSH")) {
             return this.value - 0x60 + 1;
         }
         return 0;

--- a/packages/bignumber/src.ts/bignumber.ts
+++ b/packages/bignumber/src.ts/bignumber.ts
@@ -321,7 +321,7 @@ function toHex(value: string | BN): string {
     }
 
     // Add a "0x" prefix if missing
-    if (value.substring(0, 2) !== "0x") { value = "0x" + value; }
+    if (!value.startsWith("0x")) { value = "0x" + value; }
 
     // Normalize zero
     if (value === "0x") { return "0x00"; }
@@ -330,7 +330,7 @@ function toHex(value: string | BN): string {
     if (value.length % 2) { value = "0x0" + value.substring(2); }
 
     // Trim to smallest even-length string
-    while (value.length > 4 && value.substring(0, 4) === "0x00") {
+    while (value.length > 4 && value.startsWith("0x00")) {
         value = "0x" + value.substring(4);
     }
 

--- a/packages/bignumber/src.ts/fixednumber.ts
+++ b/packages/bignumber/src.ts/fixednumber.ts
@@ -77,7 +77,7 @@ export function parseFixed(value: string, decimals?: BigNumberish): BigNumber {
     }
 
     // Is it negative?
-    const negative = (value.substring(0, 1) === "-");
+    const negative = (value.startsWith("-"));
     if (negative) { value = value.substring(1); }
 
     if (value === ".") {

--- a/packages/bytes/src.ts/index.ts
+++ b/packages/bytes/src.ts/index.ts
@@ -108,7 +108,7 @@ export function arrayify(value: BytesLike | Hexable | number, options?: DataOpti
         return addSlice(new Uint8Array(result));
     }
 
-    if (options.allowMissingPrefix && typeof(value) === "string" && value.substring(0, 2) !== "0x") {
+    if (options.allowMissingPrefix && typeof(value) === "string" && !value.startsWith("0x")) {
          value = "0x" + value;
     }
 
@@ -221,7 +221,7 @@ export function hexlify(value: BytesLike | Hexable | number | bigint, options?: 
         return "0x" + value;
     }
 
-    if (options.allowMissingPrefix && typeof(value) === "string" && value.substring(0, 2) !== "0x") {
+    if (options.allowMissingPrefix && typeof(value) === "string" && !value.startsWith("0x")) {
          value = "0x" + value;
     }
 
@@ -254,7 +254,7 @@ export function hexlify(value: BytesLike | Hexable | number | bigint, options?: 
 
 /*
 function unoddify(value: BytesLike | Hexable | number): BytesLike | Hexable | number {
-    if (typeof(value) === "string" && value.length % 2 && value.substring(0, 2) === "0x") {
+    if (typeof(value) === "string" && value.length % 2 && !value.startsWith("0x")) {
         return "0x0" + value.substring(2);
     }
     return value;


### PR DESCRIPTION
startsWith() can show stronger semantics than substring, it tells that this method is to judge if a string starts with some substring.