### PR TITLE
Optimized strings prefix judge: use startsWith instead of substring

### DIFF
--- a/src.ts/abi/fragments.ts
+++ b/src.ts/abi/fragments.ts
@@ -862,7 +862,7 @@ export class ParamType {
             return new ParamType(_guard, name || "", type, "array", indexed, null, arrayLength, arrayChildren);
         }
 
-        if (type === "tuple" || type.substring(0, 5) === "tuple(" || type[0] === "(") {
+        if (type === "tuple" || type.startsWith("tuple(") || type[0] === "(") {
             const comps = (obj.components != null) ? obj.components.map((c: any) => ParamType.from(c)): null;
             const tuple = new ParamType(_guard, name || "", type, "tuple", indexed, comps, null, null);
             // @TODO: use lexer to validate and normalize type

--- a/src.ts/abi/typed.ts
+++ b/src.ts/abi/typed.ts
@@ -102,7 +102,7 @@ export class Typed {
     }
 
     isData(): this is TypedData {
-        return (this.type.substring(0, 5) === "bytes");
+        return (this.type.startsWith("bytes"));
     }
 
     isString(): this is TypedString {

--- a/src.ts/address/address.ts
+++ b/src.ts/address/address.ts
@@ -123,7 +123,7 @@ export function getAddress(address: string): string {
     if (address.match(/^(0x)?[0-9a-fA-F]{40}$/)) {
 
         // Missing the 0x prefix
-        if (address.substring(0, 2) !== "0x") { address = "0x" + address; }
+        if (!address.startsWith("0x")) { address = "0x" + address; }
 
         const result = getChecksumAddress(address);
 

--- a/src.ts/contract/factory.ts
+++ b/src.ts/contract/factory.ts
@@ -33,7 +33,7 @@ export class ContractFactory<A extends Array<any> = Array<any>, I = BaseContract
             bytecode = hexlify(getBytes(bytecode));
         } else {
             if (typeof(bytecode) === "object") { bytecode = bytecode.object; }
-            if (bytecode.substring(0, 2) !== "0x") { bytecode = "0x" + bytecode; }
+            if (!bytecode.startsWith("0x")) { bytecode = "0x" + bytecode; }
             bytecode = hexlify(getBytes(bytecode));
         }
 

--- a/src.ts/utils/data.ts
+++ b/src.ts/utils/data.ts
@@ -147,7 +147,7 @@ export function dataSlice(data: BytesLike, start?: number, end?: number): string
  */
 export function stripZerosLeft(data: BytesLike): string {
     let bytes = hexlify(data).substring(2);
-    while (bytes.substring(0, 2) == "00") { bytes = bytes.substring(2); }
+    while (bytes.startsWith("00")) { bytes = bytes.substring(2); }
     return "0x" + bytes;
 }
 

--- a/src.ts/utils/maths.ts
+++ b/src.ts/utils/maths.ts
@@ -230,7 +230,7 @@ export function toBeArray(_value: BigNumberish): Uint8Array {
  */
 export function toQuantity(value: BytesLike | BigNumberish): string {
     let result = hexlify(isBytesLike(value) ? value: toBeArray(value)).substring(2);
-    while (result.substring(0, 1) === "0") { result = result.substring(1); }
+    while (result.startsWith("0")) { result = result.substring(1); }
     if (result === "") { result = "0"; }
     return "0x" + result;
 }

--- a/src.ts/wallet/json-keystore.ts
+++ b/src.ts/wallet/json-keystore.ts
@@ -96,7 +96,7 @@ function getAccount(data: any, _key: string): KeystoreAccount {
     const address = computeAddress(privateKey);
     if (data.address) {
         let check = data.address.toLowerCase();
-        if (check.substring(0, 2) !== "0x") { check = "0x" + check; }
+        if (check.startsWith("0x")) { check = "0x" + check; }
 
         assertArgument(getAddress(check) === address, "keystore address/privateKey mismatch", "address", data.address);
     }

--- a/src.ts/wallet/utils.ts
+++ b/src.ts/wallet/utils.ts
@@ -7,7 +7,7 @@ import {
 } from "../utils/index.js";
 
 export function looseArrayify(hexString: string): Uint8Array {
-    if (typeof(hexString) === 'string' && hexString.substring(0, 2) !== '0x') {
+    if (typeof(hexString) === 'string' && !hexString.startsWith("0x")) {
         hexString = '0x' + hexString;
     }
     return getBytesCopy(hexString);


### PR DESCRIPTION
startsWith() can show stronger semantics than substring, it tells that this method is to judge if a string starts with some substring.