### PR TITLE
Added type for options param in getDefaultProvider function

### DIFF
--- a/src.ts/ethers.ts
+++ b/src.ts/ethers.ts
@@ -145,7 +145,7 @@ export type { ProgressCallback, SignatureLike } from "./crypto/index.js";
 export type { TypedDataDomain, TypedDataField } from "./hash/index.js";
 
 export type {
-    Provider, Signer
+    Provider, Signer, GetDefaultProviderOptions
 } from "./providers/index.js";
 
 export type {

--- a/src.ts/providers/default-provider.ts
+++ b/src.ts/providers/default-provider.ts
@@ -22,7 +22,16 @@ function isWebSocketLike(value: any): value is WebSocketLike {
         typeof(value.close) === "function");
 }
 
-export function getDefaultProvider(network: string | Networkish | WebSocketLike, options?: any): AbstractProvider {
+export type GetDefaultProviderOptions = {
+    alchemy?: string | undefined | null
+    ankr?: string | undefined | null
+    cloudflare?: string | undefined | null
+    etherscan?: string | undefined 
+    infura?: string | { projectSecret: string, projectId: null | string } | null
+    quicknode?: string | undefined | null
+}
+
+export function getDefaultProvider(network: string | Networkish | WebSocketLike, options?: GetDefaultProviderOptions): AbstractProvider {
     if (options == null) { options = { }; }
 
     if (typeof(network) === "string" && network.match(/^https?:/)) {
@@ -64,8 +73,8 @@ export function getDefaultProvider(network: string | Networkish | WebSocketLike,
             let projectId = options.infura;
             let projectSecret: undefined | string = undefined;
             if (typeof(projectId) === "object") {
-                projectSecret = projectId.projectSecret;
-                projectId = projectId.projectId;
+                projectSecret = projectId?.projectSecret;
+                projectId = projectId?.projectId;
             }
             providers.push(new InfuraProvider(network, projectId, projectSecret));
         } catch (error) { console.log(error); }

--- a/src.ts/providers/default-provider.ts
+++ b/src.ts/providers/default-provider.ts
@@ -87,7 +87,7 @@ export function getDefaultProvider(network: string | Networkish | WebSocketLike,
 */
     if (options.quicknode !== "-") {
         try {
-            let token = options.qquicknode;
+            let token = options.quicknode;
             providers.push(new QuickNodeProvider(network, token));
         } catch (error) { console.log(error); }
     }

--- a/src.ts/providers/index.ts
+++ b/src.ts/providers/index.ts
@@ -120,3 +120,4 @@ export type {
 
 export type { Signer } from "./signer.js";
 
+export type { GetDefaultProviderOptions } from './default-provider'


### PR DESCRIPTION
I was using this function and I found that the type for the `options` argument in `getDefaultProvider` was missing.

I've made the PR in the `v6` branch where I also found that `quicknode` was misspelled and I fixed it to add it to the type.