### PR TITLE
Max priority fee per gas should be 1 nanoeth

### DIFF
--- a/packages/abstract-provider/src.ts/index.ts
+++ b/packages/abstract-provider/src.ts/index.ts
@@ -249,7 +249,7 @@ export abstract class Provider implements OnceBlockable {
             // using the formula "check if the base fee is correct".
             // See: https://eips.ethereum.org/EIPS/eip-1559
             lastBaseFeePerGas = block.baseFeePerGas;
-            maxPriorityFeePerGas = BigNumber.from("1500000000");
+            maxPriorityFeePerGas = BigNumber.from("1000000000");
             maxFeePerGas = block.baseFeePerGas.mul(2).add(maxPriorityFeePerGas);
         }
 


### PR DESCRIPTION
I believe that the default priority fee across all (citation needed) clients is 1 nanoeth per gas. Since the switch to Proof of Stake, the opportunity cost of transaction inclusion dropped *dramatically* since block production is no longer competitive in the same way as under PoW. To produce a very big block, one needs to submit it a little bit sooner than if you are producing a tiny block, which means you will miss out on fees for new transactions that come in between those two points in time (I believe the difference is measured in milliseconds).

Given all of the above, I don't see any compelling argument for setting this over 1, and reducing it to 1 will save users 33% on priority fees compared to the current value, and this change is generally a boon to the community/ecosystem.