### PR TITLE
Correction of Spelling and Grammar Mistakes in Documentation v6

### DIFF
--- a/docs.wrm/contributing.wrm
+++ b/docs.wrm/contributing.wrm
@@ -1,4 +1,4 @@
-_section: Contributings and Hacking @<about-contrib> @priority<-90>
+_section: Contributions and Hacking @<about-contrib> @priority<-90>
 
 Pull requests are welcome, but please keep the following in mind:
 
@@ -93,7 +93,7 @@ _subsection: Adding Features  @<about-contrib-feature>
 
 Contributing new features usually require a deeper understanding
 of the internal interactions with Ethers and its components, and
-generally requires a minor version bumpincludes anything w
+generally requires a minor version bump includes anything w
 
 When making any of the following changes, you must first open a
 [[link-discussion]] as the minor version will need to be bumped.

--- a/docs.wrm/getting-started.wrm
+++ b/docs.wrm/getting-started.wrm
@@ -48,7 +48,7 @@ objects available and what they are responsible for, at a high level.
 _heading: Provider
 
 A [[Provider]] is a read-only connection to the blockchain, which allows
-querying the blockchain state, such as accout, block or transaction details,
+querying the blockchain state, such as account, block or transaction details,
 querying event logs or evaluating read-only code using call.
 
 If you are coming from Web3.js, you are used to a **Provider** offering
@@ -118,7 +118,7 @@ extension that injects objects into the ``window``, providing:
 - authenticated write access backed by a private key (a [[Signer]])
 
 When requesting access to the authenticated methods, such as
-sending a transaction or even requesting the private key addess,
+sending a transaction or even requesting the private key address,
 MetaMask will show a pop-up to the user asking for permission.
 
 _code:  @lang<script>
@@ -172,7 +172,7 @@ _code: connecting to a JSON-RPC URL  @lang<script>
 _subsection: User Interaction  @<starting-display>
 
 All units in Ethereum tend to be integer values, since dealing with
-decimals and floating points can lead to inprecise and non-obvious
+decimals and floating points can lead to imprecise and non-obvious
 results when performing mathematic operations.
 
 As a result, the internal units used (e.g. wei) which are suited for
@@ -272,7 +272,7 @@ _subsection: Contracts  @<starting-contracts>
 
 A **Contract** is a meta-class, which means that its definition
 its derived at run-time, based on the ABI it is passed, which then
-determined what mehods and properties are available on it.
+determined what methods and properties are available on it.
 
 _heading: Application Binary Interface (ABI)
 
@@ -291,7 +291,7 @@ Any methods or events that are not needed can be safely excluded.
 There are several common formats available to describe an ABI. The
 Solidity compiler usually dumps a JSON representation but when typing
 an ABI by hand it is often easier (and more readable) to use the
-human-readable ABI, which is just the Solidity signautre.
+human-readable ABI, which is just the Solidity signature.
 
 _code: simplified ERC-20 ABI @lang<script>
   abi = [
@@ -478,7 +478,7 @@ it. It can also be used to sign other forms of data, which are then able
 to be validated for other purposes.
 
 For example, signing **a message** can be used to prove ownership of an
-account which a website could use to authenicate a user and log them in.
+account which a website could use to authenticate a user and log them in.
 
 _code:  @lang<javascript>
 

--- a/docs.wrm/index.wrm
+++ b/docs.wrm/index.wrm
@@ -3,7 +3,7 @@ _section: Documentation  @<about-home> @nav<Documentation>
 The ethers.js library aims to be a complete and compact library
 for interacting with the Ethereum Blockchain and its ecosystem.
 
-It is ofen used to create decentralized applications (dapps),
+It is often used to create decentralized applications (dapps),
 wallets (such as [[link-metamask]] and [[link-tally]]) and
 other tools and simple scripts that require reading and writing
 to the blockchain.
@@ -14,7 +14,7 @@ _subsection: About this documentation?
 These docs are still under construction, and are being expanded
 every day.
 
-Developers new to Ethers shoud be sure to read through the
+Developers new to Ethers should be sure to read through the
 [[getting-started]] section.
 
 And the [[about-api]] is available for drilling down into more details


### PR DESCRIPTION
I figured there were some known typos when I landed on the v6 documentation through a follow-up link from the metamask documentation. 

All edits were made in the docs.wrm folder in a single commit. 

This PR addresses the issue https://github.com/ethers-io/ethers.js/issues/3101