### PR TITLE
Fix Single Provider in the FallbackProvider Array

### DIFF
--- a/src.ts/providers/provider-fallback.ts
+++ b/src.ts/providers/provider-fallback.ts
@@ -250,6 +250,8 @@ function getMedian(quorum: number, results: Array<TallyResult>): undefined | big
     // Get the sorted values
     values.sort((a, b) => ((a < b) ? -1: (b > a) ? 1: 0));
 
+    if (values.length === 1) { return values[0]; }
+
     const mid = values.length / 2;
 
     // Odd-length; take the middle value


### PR DESCRIPTION
Fix the corner case where if only one provider was passed in the FallbackProvider array it would cause errors even simply on the provider.getBlockNumber().

Fix the issue #3745 