### PR TITLE
Research on enabling alternative EIP 2718 Typed Transactions

### DIFF
--- a/src.ts/providers/abstract-provider.ts
+++ b/src.ts/providers/abstract-provider.ts
@@ -615,6 +615,7 @@ export class AbstractProvider implements Provider {
         return resolve(<Array<string>>address, fromBlock, toBlock);
     }
 
+    // RESEARCH apart from TS types this looks like it would work without modification (assuming copyRequest stops dropping properties)
     _getTransactionRequest(_request: TransactionRequest): PerformActionTransaction | Promise<PerformActionTransaction> {
         const request = <PerformActionTransaction>copyRequest(_request);
 
@@ -859,7 +860,7 @@ export class AbstractProvider implements Provider {
              }),
              network: this.getNetwork()
         });
-
+        // RESEARCH -- if Transaction is subclassed then this will need to use that class.
         const tx = Transaction.from(signedTx);
         if (tx.hash !== hash) {
             throw new Error("@TODO: the returned hash did not match");

--- a/src.ts/providers/abstract-signer.ts
+++ b/src.ts/providers/abstract-signer.ts
@@ -207,6 +207,7 @@ export abstract class AbstractSigner<P extends null | Provider = null | Provider
 
         const pop = await this.populateTransaction(tx);
         delete pop.from;
+        // RESEARCH -- if Transaction is subclassed then this will need to use that class.
         const txObj = Transaction.from(pop);
         return await provider.broadcastTransaction(await this.signTransaction(txObj));
     }

--- a/src.ts/providers/provider.ts
+++ b/src.ts/providers/provider.ts
@@ -100,7 +100,7 @@ export class FeeData {
     }
 }
 
-
+// RESEARCH allow additional properties
 export interface TransactionRequest {
     type?: null | number;
 
@@ -157,7 +157,8 @@ export interface PreparedTransactionRequest {
     enableCcipRead?: boolean;
 }
 
-export function copyRequest(req: TransactionRequest): PreparedTransactionRequest {
+// RESEARCH will need to allow for additional keys in req to be in result
+export function copyRequest<T extends TransactionRequest = TransactionRequest>(req: T): PreparedTransactionRequest {
     const result: any = { };
 
     // These could be addresses, ENS names or Addressables
@@ -567,7 +568,7 @@ export interface ByzantiumTransactionReceipt {
     root: null;
 }
 */
-
+// RESEARCH -- probably should include additional tx properties
 export class TransactionReceipt implements TransactionReceiptParams, Iterable<Log> {
     readonly provider!: Provider;
 
@@ -627,6 +628,7 @@ export class TransactionReceipt implements TransactionReceiptParams, Iterable<Lo
 
     get logs(): ReadonlyArray<Log> { return this.#logs; }
 
+    // RESEARCH -- probably should return additional tx properties
     toJSON(): any {
         const {
             to, from, contractAddress, hash, index, blockHash, blockNumber, logsBloom,

--- a/src.ts/providers/signer.ts
+++ b/src.ts/providers/signer.ts
@@ -55,7 +55,7 @@ export interface Signer extends Addressable, ContractRunner, NameResolver {
      *
      *  @param tx - The call to prepare
      */
-    populateCall(tx: TransactionRequest): Promise<TransactionLike<string>>;
+    populateCall<T extends TransactionRequest = TransactionRequest>(tx: T): Promise<TransactionLike<string>>;
 
     /**
      *  Prepares a {@link TransactionRequest} for sending to the network by
@@ -74,7 +74,7 @@ export interface Signer extends Addressable, ContractRunner, NameResolver {
      *
      *  @param tx - The call to prepare
      */
-    populateTransaction(tx: TransactionRequest): Promise<TransactionLike<string>>;
+    populateTransaction<T extends TransactionRequest = TransactionRequest>(tx: T): Promise<TransactionLike<string>>;
 
 
     ////////////////////
@@ -95,7 +95,7 @@ export interface Signer extends Addressable, ContractRunner, NameResolver {
      *          node to take into account. In these cases, a manually determined ``gasLimit``
      *          will need to be made.
      */
-    estimateGas(tx: TransactionRequest): Promise<bigint>;
+    estimateGas<T extends TransactionRequest = TransactionRequest>(tx: T): Promise<bigint>;
 
     /**
      *  Evaluates the //tx// by running it against the current Blockchain state. This
@@ -106,7 +106,7 @@ export interface Signer extends Addressable, ContractRunner, NameResolver {
      *  (e.g. running a Contract's getters) or to simulate the effect of a transaction
      *  before actually performing an operation.
      */
-    call(tx: TransactionRequest): Promise<string>;
+    call<T extends TransactionRequest = TransactionRequest>(tx: T): Promise<string>;
 
     /**
      *  Resolves an [[Address]] or ENS Name to an [[Address]].
@@ -121,14 +121,14 @@ export interface Signer extends Addressable, ContractRunner, NameResolver {
      *  Signs %%tx%%, returning the fully signed transaction. This does not
      *  populate any additional properties within the transaction.
      */
-    signTransaction(tx: TransactionRequest): Promise<string>;
+    signTransaction<T extends TransactionRequest = TransactionRequest>(tx: T): Promise<string>;
 
     /**
      *  Sends %%tx%% to the Network. The ``signer.populateTransaction(tx)``
      *  is called first to ensure all necessary properties for the
      *  transaction to be valid have been popualted first.
      */
-    sendTransaction(tx: TransactionRequest): Promise<TransactionResponse>;
+    sendTransaction<T extends TransactionRequest = TransactionRequest>(tx: T): Promise<TransactionResponse>;
 
     /**
      *  Signers an [[EIP-191]] prefixed personal message.

--- a/src.ts/transaction/transaction.ts
+++ b/src.ts/transaction/transaction.ts
@@ -386,6 +386,8 @@ export class Transaction implements TransactionLike<string> {
      *  explicit properties.
      */
     get type(): null | number { return this.#type; }
+
+    // RESEARCH -- will need to allow for other type numbers
     set type(value: null | number | string) {
         switch (value) {
             case null:
@@ -408,6 +410,7 @@ export class Transaction implements TransactionLike<string> {
     /**
      *  The name of the transaction type.
      */
+    // REASEARCH --- probably not necessary but also a place where tx type is limited
     get typeName(): null | string {
         switch (this.type) {
             case 0: return "legacy";
@@ -549,6 +552,7 @@ export class Transaction implements TransactionLike<string> {
         this.#chainId = BigInt(0);
         this.#sig = null;
         this.#accessList = null;
+        // RESEARCH -- add parameter
     }
 
     /**
@@ -613,7 +617,7 @@ export class Transaction implements TransactionLike<string> {
             case 2:
                 return _serializeEip1559(this, this.signature);
         }
-
+        // RESEARCH -- allow other types
         assert(false, "unsupported transaction type", "UNSUPPORTED_OPERATION", { operation: ".serialized" });
     }
 
@@ -632,7 +636,7 @@ export class Transaction implements TransactionLike<string> {
             case 2:
                 return _serializeEip1559(this);
         }
-
+        // RESEARCH -- allow other types
         assert(false, "unsupported transaction type", "UNSUPPORTED_OPERATION", { operation: ".unsignedSerialized" });
     }
 
@@ -760,6 +764,7 @@ export class Transaction implements TransactionLike<string> {
             chainId: s(this.chainId),
             sig: this.signature ? this.signature.toJSON(): null,
             accessList: this.accessList
+            // RESEARCH -- include other params
         };
     }
 
@@ -781,6 +786,7 @@ export class Transaction implements TransactionLike<string> {
                 case 1: return Transaction.from(_parseEip2930(payload));
                 case 2: return Transaction.from(_parseEip1559(payload));
             }
+            // RESEARCH -- allow other types
             assert(false, "unsupported transaction type", "UNSUPPORTED_OPERATION", { operation: "from" });
         }
 

--- a/src.ts/wallet/base-wallet.ts
+++ b/src.ts/wallet/base-wallet.ts
@@ -86,6 +86,7 @@ export class BaseWallet extends AbstractSigner {
         }
 
         // Build the transaction
+        // RESEARCH -- if Transaction is subclassed then this will need to use that class. 
         const btx = Transaction.from(<TransactionLike<string>>tx);
         btx.signature = this.signingKey.sign(btx.unsignedHash);
 


### PR DESCRIPTION
Preliminary study of what would cause issue with using ethers with transaction types not yet supported / used by ethereum mainnet but potentially by layer 2s and other evm chains . 

These transactions require 

A) extra properties on the TransactionRequest object to NOT be removed by any internal functions
B) Not throwing if the type is set to number valid according to the EIP2718 spec (up to 124 i believe)

Also but less critical
C) For typescript types to work 



#3747