### PR TITLE
Re-ordered Export Types

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,64 +34,64 @@
   "ethereum": "donations.ethers.eth",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./lib.esm/index.js",
-      "require": "./lib.commonjs/index.js",
-      "types": "./types/index.d.ts"
+      "require": "./lib.commonjs/index.js"
     },
     "./abi": {
+      "types": "./types/abi/index.d.ts",
       "import": "./lib.esm/abi/index.js",
-      "require": "./lib.commonjs/abi/index.js",
-      "types": "./types/abi/index.d.ts"
+      "require": "./lib.commonjs/abi/index.js"
     },
     "./address": {
+      "types": "./types/address/index.d.ts",
       "import": "./lib.esm/address/index.js",
-      "require": "./lib.commonjs/address/index.js",
-      "types": "./types/address/index.d.ts"
+      "require": "./lib.commonjs/address/index.js"
     },
     "./constants": {
+      "types": "./types/constants/index.d.ts",
       "import": "./lib.esm/constants/index.js",
-      "require": "./lib.commonjs/constants/index.js",
-      "types": "./types/constants/index.d.ts"
+      "require": "./lib.commonjs/constants/index.js"
     },
     "./contract": {
+      "types": "./types/contract/index.d.ts",
       "import": "./lib.esm/contract/index.js",
-      "require": "./lib.commonjs/contract/index.js",
-      "types": "./types/contract/index.d.ts"
+      "require": "./lib.commonjs/contract/index.js"
     },
     "./crypto": {
+      "types": "./types/crypto/index.d.ts",
       "import": "./lib.esm/crypto/index.js",
-      "require": "./lib.commonjs/crypto/index.js",
-      "types": "./types/crypto/index.d.ts"
+      "require": "./lib.commonjs/crypto/index.js"
     },
     "./hash": {
+      "types": "./types/hash/index.d.ts",
       "import": "./lib.esm/hash/index.js",
-      "require": "./lib.commonjs/hash/index.js",
-      "types": "./types/hash/index.d.ts"
+      "require": "./lib.commonjs/hash/index.js"
     },
     "./providers": {
+      "types": "./types/providers/index.d.ts",
       "import": "./lib.esm/providers/index.js",
-      "require": "./lib.commonjs/providers/index.js",
-      "types": "./types/providers/index.d.ts"
+      "require": "./lib.commonjs/providers/index.js"
     },
     "./transaction": {
+      "types": "./types/transaction/index.d.ts",
       "import": "./lib.esm/transaction/index.js",
-      "require": "./lib.commonjs/transaction/index.js",
-      "types": "./types/transaction/index.d.ts"
+      "require": "./lib.commonjs/transaction/index.js"
     },
     "./utils": {
+      "types": "./types/utils/index.d.ts",
       "import": "./lib.esm/utils/index.js",
-      "require": "./lib.commonjs/utils/index.js",
-      "types": "./types/utils/index.d.ts"
+      "require": "./lib.commonjs/utils/index.js"
     },
     "./wallet": {
+      "types": "./types/wallet/index.d.ts",
       "import": "./lib.esm/wallet/index.js",
-      "require": "./lib.commonjs/wallet/index.js",
-      "types": "./types/wallet/index.d.ts"
+      "require": "./lib.commonjs/wallet/index.js"
     },
     "./wordlists": {
+      "types": "./types/wordlists/index.d.ts",
       "import": "./lib.esm/wordlists/index.js",
-      "require": "./lib.commonjs/wordlists/index.js",
-      "types": "./types/wordlists/index.d.ts"
+      "require": "./lib.commonjs/wordlists/index.js"
     }
   },
   "funding": [


### PR DESCRIPTION
Re-ordered Export Types in packages to comply with TypeScripts recommendation when deploying types with packages.

Links for reference:

Detected running a lint:
https://publint.dev/ethers@6.0.2

Lint error definition:
https://publint.dev/rules#exports_types_should_be_first

TypeScript Docs:
https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing


Additional notes:
These are *non-breaking changes* 🙂 