### PR TITLE
Fix "duplicate names" assertion in array coder

### DIFF
--- a/src.ts/abi/coders/array.ts
+++ b/src.ts/abi/coders/array.ts
@@ -26,7 +26,7 @@ export function pack(writer: Writer, coders: ReadonlyArray<Coder>, values: Array
             assert(name, "cannot encode object for signature with missing names",
                 "INVALID_ARGUMENT", { argument: "values", info: { coder }, value: values });
 
-            assert(unique[name], "cannot encode object for signature with duplicate names",
+            assert(!unique[name], "cannot encode object for signature with duplicate names",
                 "INVALID_ARGUMENT", { argument: "values", info: { coder }, value: values });
 
             unique[name] = true;


### PR DESCRIPTION
Just a one line bug fix -- the assertion should fail if name *has* been seen before; currently it fails if it hasn't.