### PR TITLE
Format API results inside `_wrap*` methods

### DIFF
--- a/src.ts/providers/abstract-provider.ts
+++ b/src.ts/providers/abstract-provider.ts
@@ -492,7 +492,7 @@ export class AbstractProvider implements Provider {
     }
 
     _wrapTransactionResponse(tx: TransactionResponseParams, network: Network): TransactionResponse {
-        return new TransactionResponse(tx, this);
+        return new TransactionResponse(formatTransactionResponse(tx), this);
     }
 
     _detectNetwork(): Promise<Network> {
@@ -893,7 +893,7 @@ export class AbstractProvider implements Provider {
         });
         if (params == null) { return null; }
 
-        return this._wrapBlock(formatBlock(params), network);
+        return this._wrapBlock(params, network);
     }
 
     async getTransaction(hash: string): Promise<null | TransactionResponse> {
@@ -903,7 +903,7 @@ export class AbstractProvider implements Provider {
         });
         if (params == null) { return null; }
 
-        return this._wrapTransactionResponse(formatTransactionResponse(params), network);
+        return this._wrapTransactionResponse(params, network);
     }
 
     async getTransactionReceipt(hash: string): Promise<null | TransactionReceipt> {
@@ -921,7 +921,7 @@ export class AbstractProvider implements Provider {
             params.effectiveGasPrice = tx.gasPrice;
         }
 
-        return this._wrapTransactionReceipt(formatTransactionReceipt(params), network);
+        return this._wrapTransactionReceipt(params, network);
     }
 
     async getTransactionResult(hash: string): Promise<null | string> {
@@ -943,7 +943,7 @@ export class AbstractProvider implements Provider {
             params: this.#perform<Array<LogParams>>({ method: "getLogs", filter })
         });
 
-        return params.map((p) => this._wrapLog(formatLog(p), network));
+        return params.map((p) => this._wrapLog(p, network));
     }
 
     // ENS


### PR DESCRIPTION
There are 4 wrapping methods in `AbstractProvider`:

- `_wrapBlock`
- `_wrapLog`
- `_wrapTransactionReceipt`
- `_wrapTransactionResponse`

For some reason, `formatTransactionResponse` was not being called in `_wrapTransactionResponse`, although the analogous functions were being called in other wrapping methods.

Also, for some reason, formatting functions were being called on the arguments of wrapping methods before being passed in, even though they are called inside as well.

This PR fixes the inconsistencies.

The argument for formatting functions to be called inside wrapping methods is that if we want to override the formatters in the derived Provider class (say, if a network has extra fields in `Block` or `TransactionReceipt`), it is much easier to do so by overriding wrapping methods than by overriding every method that calls wrapping methods.