### PR TITLE
Fix logic error in getSigner

### DIFF
--- a/src.ts/providers/provider-jsonrpc.ts
+++ b/src.ts/providers/provider-jsonrpc.ts
@@ -932,7 +932,7 @@ export abstract class JsonRpcApiProvider extends AbstractProvider {
         // Account address
         address = getAddress(address);
         for (const account of accounts) {
-            if (getAddress(account) === account) {
+            if (getAddress(account) === address) {
                 return new JsonRpcSigner(this, account);
             }
         }


### PR DESCRIPTION
Hopefully self-explaining.

This should also be tested, but I won't be able to do that, sorry.

This is a showstopper for Hardhat because we rely on `getSigner` a lot.