### PR TITLE
Add EIP1193 required event method types from NodeJS.EventEmitter definitions

### DIFF
--- a/src.ts/providers/provider-browser.ts
+++ b/src.ts/providers/provider-browser.ts
@@ -11,6 +11,8 @@ import type { Networkish } from "./network.js";
 
 export interface Eip1193Provider {
     request(request: { method: string, params?: Array<any> | Record<string, any> }): Promise<any>;
+    on(eventName: string | symbol, listener: (...args: any[]) => void): this;
+    removeListener(eventName: string | symbol, listener: (...args: any[]) => void): this;
 };
 
 export type DebugEventBrowserProvider = {


### PR DESCRIPTION
The Eip1193Provider does not have types for the event methods ``on`` and ``removeListener``
https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1193.md#events
> The Provider **MUST** implement the following event handling methods:
> 
>   - ``on``
>   - ``removeListener``
>
> These methods **MUST** be implemented per the Node.js [``EventEmitter`` API](https://nodejs.org/api/events.html).

This change adds the ``on`` and ``removeListener`` method types from NodeJS.EventEmitter definitions.

How I currently type the injected Eip1193:
```ts
import type { Eip1193Provider } from 'ethers/types/providers';

declare global {
	interface Window {
		ethereum: (Eip1193Provider & NodeJS.EventEmitter) | undefined;
	}
}
```