### PR TITLE
Support xdc-prefix address

### DIFF
--- a/packages/address/src.ts/index.ts
+++ b/packages/address/src.ts/index.ts
@@ -81,6 +81,10 @@ export function getAddress(address: string): string {
         logger.throwArgumentError("invalid address", "address", address);
     }
 
+    if (address && address.length === 43 && address.slice(0, 3) === 'xdc') {
+        address = '0x' + address.slice(3);
+    }
+
     if (address.match(/^(0x)?[0-9a-fA-F]{40}$/)) {
 
         // Missing the 0x prefix

--- a/packages/providers/src.ts/formatter.ts
+++ b/packages/providers/src.ts/formatter.ts
@@ -323,6 +323,10 @@ export class Formatter {
             transaction.gasLimit = transaction.gas;
         }
 
+        if (transaction.to && transaction.to.length === 43 && transaction.to.slice(0, 3) === 'xdc') {
+            transaction.to = '0x' + transaction.to.slice(3);
+        }
+
         // Some clients (TestRPC) do strange things like return 0x0 for the
         // 0 address; correct this to be a real address
         if (transaction.to && BigNumber.from(transaction.to).isZero()) {


### PR DESCRIPTION
The [xinfin blockchain](https://www.xinfin.org/) use `xdc` as address prefix, not `0x`. Below is an example:

```shell
curl -s -X POST https://rpc.apothem.network/ -H "Content-Type: application/json" -d '
{
  "jsonrpc": "2.0",
  "method": "eth_getBlockByNumber",
  "params": ["latest", true],
  "id":1
}' | jq
```

![1678180418905](https://user-images.githubusercontent.com/7695325/223376916-9711c860-971c-487b-84e7-dede403b33ee.png)

This PR replace `xdc` address prefix with `0x` in function:
- `packages/address/src.ts/index.ts: getAddress` 
- `packages/providers/src.ts/formatter.ts: transactionResponse`

to support xinfin blockchain, include mainnet xinfin and testnet apothem.

