### PR TITLE
Drop unreachable code after return statement

### DIFF
--- a/src.ts/abi/fragments.ts
+++ b/src.ts/abi/fragments.ts
@@ -195,7 +195,6 @@ class TokenString {
                 linkBack: (t.linkBack - from),
                 linkNext: (t.linkNext - from),
             }));
-            return t;
         }));
     }
 


### PR DESCRIPTION
...which triggers a browser console warning in any Dapp using ethers.