### PR TITLE
Typo in exception at 's' prop of Signature Solved

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ethers",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ethers",
-      "version": "6.0.0",
+      "version": "6.1.0",
       "funding": [
         {
           "type": "individual",

--- a/src.ts/crypto/signature.ts
+++ b/src.ts/crypto/signature.ts
@@ -73,7 +73,7 @@ export class Signature {
      */
     get r(): string { return this.#r; }
     set r(value: BytesLike) {
-        assertArgument(dataLength(value) === 32, "invalid r", "value", value);
+        assertArgument(dataLength(value) === 32, "invalid s", "value", value);
         this.#r = hexlify(value);
     }
 


### PR DESCRIPTION
Fixes #3891

Necessary changes are made.
Changed `invalid r` to `invalid s`

Signed off by Aadit Palande