### PR TITLE
Add `hasEvent` and `hasFunction` methods to contract and interface

### DIFF
--- a/src.ts/_tests/test-contract.ts
+++ b/src.ts/_tests/test-contract.ts
@@ -177,6 +177,32 @@ describe("Test Contract", function() {
         await specificEvent;
         await allEvents;
     });
+
+    it("tests hasFunction", async function() {
+        const contract = new Contract(addr, abi);
+
+        assert.equal(contract.hasFunction('testCallAdd'), true);
+        assert.equal(contract.hasFunction('notExistFn'), false);
+        assert.equal(contract.hasFunction('function testCallAdd(uint256 a, uint256 b) pure returns (uint256 result)'), true);
+        assert.equal(contract.hasFunction('function testCallAdd(uint256 a) pure returns (uint256 result)'), false);
+        assert('testCallAdd' in contract);
+        assert(!('notExistFn' in contract));
+        assert('function testCallAdd(uint256 a, uint256 b) pure returns (uint256 result)' in contract);
+        assert(!('function testCallAdd(uint256 a) pure returns (uint256 result)' in contract));
+    });
+
+    it("tests hasEvent", async function() {
+        const contract = new Contract(addr, abi);
+
+        assert.equal(contract.hasEvent('EventUint256'), true);
+        assert.equal(contract.hasEvent('NotExistEvent'), false);
+        assert.equal(contract.hasEvent('event EventUint256(uint256 indexed value)'), true);
+        assert.equal(contract.hasEvent('event EventUint256()'), false);
+        assert('EventUint256' in contract.filters);
+        assert(!('NotExistEvent' in contract.filters));
+        assert('event EventUint256(uint256 indexed value)' in contract.filters);
+        assert(!('event EventUint256()' in contract.filters));
+    });
 });
 
 describe("Test Typed Contract Interaction", function() {

--- a/src.ts/abi/interface.ts
+++ b/src.ts/abi/interface.ts
@@ -408,6 +408,14 @@ export class Interface {
     }
 
     /**
+     *  Check if interface has function %%key%%, which may be a function
+     *  selector, function name or function signature that belongs to the ABI.
+     */
+    hasFunction(key: string): boolean {
+        return !!this.#getFunction(key, null, false);
+    }
+
+    /**
      *  Get the function name for %%key%%, which may be a function selector,
      *  function name or function signature that belongs to the ABI.
      */
@@ -502,6 +510,14 @@ export class Interface {
         if (result) { return result; }
 
         return null;
+    }
+
+    /**
+     *  Check if interface has event %%key%%, which may be a topic hash,
+     *  event name or event signature that belongs to the ABI.
+     */
+    hasEvent(key: string): boolean {
+        return !!this.#getEvent(key, null, false);
     }
 
     /**

--- a/src.ts/contract/contract.ts
+++ b/src.ts/contract/contract.ts
@@ -685,7 +685,11 @@ export class BaseContract implements Addressable, EventEmitterable<ContractEvent
                 if (result) { return result; }
 
                 throw new Error(`unknown contract event: ${ prop }`);
-            }
+            },
+            has: (target, _prop) => (
+              Reflect.has(target, _prop) ||
+              this.hasEvent(String(_prop))
+            ),
         });
         defineProperties<BaseContract>(this, { filters });
 
@@ -706,7 +710,11 @@ export class BaseContract implements Addressable, EventEmitterable<ContractEvent
                 if (result) { return result; }
 
                 throw new Error(`unknown contract method: ${ prop }`);
-            }
+            },
+            has: (target, _prop) => (
+              Reflect.has(target, _prop) ||
+              this.hasFunction(String(_prop))
+            ),
         });
 
     }
@@ -762,9 +770,19 @@ export class BaseContract implements Addressable, EventEmitterable<ContractEvent
         return getInternal(this).deployTx;
     }
 
+    hasFunction(key: string | FunctionFragment): boolean {
+        if (typeof(key) !== "string") { key = key.format(); }
+        return this.interface.hasFunction(key);
+    }
+
     getFunction<T extends ContractMethod = ContractMethod>(key: string | FunctionFragment): T {
         if (typeof(key) !== "string") { key = key.format(); }
         return <T><unknown>(new WrappedMethod(this, key));
+    }
+
+    hasEvent(key: string | EventFragment): boolean {
+        if (typeof(key) !== "string") { key = key.format(); }
+        return this.interface.hasEvent(key);
     }
 
     getEvent(key: string | EventFragment): ContractEvent {


### PR DESCRIPTION
### Motivation:
Sometimes we need to check if the contract that was created in another part of the code contains the function or event we need. Now we have to call the `getFunction`/`getEvent` function and catch the exception.

This PR adds a simple check for the presence of functions and events in the interface. Note that these methods do not check that the contract actually supports them.

Handling of the `has` trap for the contract and filters has also been added. So the check can now be done, including using the `in` operator:
```js
if ('transfer' in contract) {...}
if ('Transfer' in contract.filters) {...}
```
It is good behavior to override `get` and `has` proxy traps at the same time.