### PR TITLE
fix build error in 'moduleResolution: node' project

### DIFF
--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -5,6 +5,7 @@
   ],
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
+    "moduleResolution": "node",
     "declaration": true,
     "declarationMap": true,
     "declarationDir": "./types",

--- a/types/providers/provider-ipcsocket.d.ts
+++ b/types/providers/provider-ipcsocket.d.ts
@@ -1,4 +1,4 @@
-/// <reference types="node" resolution-mode="require"/>
+/// <reference types="node" />
 import { SocketProvider } from "./provider-socket.js";
 import type { Socket } from "net";
 import type { Networkish } from "./network.js";


### PR DESCRIPTION
fix build error in project which config: "moduleResolution": "node" :
```
node_modules/ethers/types/providers/provider-ipcsocket.d.ts:1:23 - error TS1452: 'resolution-mode' assertions are only supported when `moduleResolution` is `node16` or `nodenext`.
```
 