### PR TITLE
Fix: Error on Events triggering #3767

### DIFF
--- a/src.ts/providers/abstract-provider.ts
+++ b/src.ts/providers/abstract-provider.ts
@@ -203,6 +203,16 @@ async function getSubscription(_event: ProviderEvent, provider: AbstractProvider
         return { type: "orphan", tag: getTag("orphan", event), filter: copy(event) };
     }
 
+    if (typeof _event === 'string') {
+        try {
+            // `_event` could be an unparsed json string somehow?
+            // fixes https://github.com/ethers-io/ethers.js/issues/3767
+            _event = JSON.parse(_event);
+        } catch (e) {
+            //
+        }
+    }
+
     if (((<any>_event).address || (<any>_event).topics)) {
         const event = <EventFilter>_event;
 


### PR DESCRIPTION
@ricmoo There might be a better way; not sure why the event is a JSON string in the first place. Perhaps it was `JSON.stringify` somewhere it shouldn't have?