### PR TITLE
Fix `getText` description

### DIFF
--- a/src.ts/providers/ens-resolver.ts
+++ b/src.ts/providers/ens-resolver.ts
@@ -267,7 +267,7 @@ export class EnsResolver {
     }
 
     /**
-     *  Resolves to the EIP-643 text record for %%key%%, or ``null``
+     *  Resolves to the EIP-634 text record for %%key%%, or ``null``
      *  if unconfigured.
      */
     async getText(key: string): Promise<null | string> {


### PR DESCRIPTION
Updates the EIP number which was mistyped.