### PR TITLE
Fix/4056

### DIFF
--- a/src.ts/contract/contract.ts
+++ b/src.ts/contract/contract.ts
@@ -621,7 +621,7 @@ export class BaseContract implements Addressable, EventEmitterable<ContractEvent
         Object.defineProperty(this, internal, { value: { } });
 
         let addrPromise;
-        let addr = null;
+        let addr: null | string = null;
 
         let deployTx: null | ContractTransactionResponse = null;
         if (_deployTx) {

--- a/src.ts/contract/contract.ts
+++ b/src.ts/contract/contract.ts
@@ -304,14 +304,19 @@ function buildWrappedMethod<A extends Array<any> = Array<any>, R = any, D extend
         try {
             result = await runner.call(tx);
         } catch (error: any) {
-            if (isCallException(error) && error.data) {
-                throw contract.interface.makeError(error.data, tx);
+            if (error.data) {
+                result = error.data;
+            } else {
+                throw error;
             }
-            throw error;
         }
 
         const fragment = getFragment(...args);
-        return contract.interface.decodeFunctionResult(fragment, result);
+        try {
+            return contract.interface.decodeFunctionResult(fragment, result);
+        } catch (error) {
+            throw contract.interface.makeError(result, tx);
+        }
     };
 
     const method = async (...args: ContractMethodArgs<A>) => {


### PR DESCRIPTION
Fix for bug #4056

The HTTPProvider creates a call exception when the transaction rolls back in a static call execution. This doesn't allow the call to parse correctly the result and output correctly.

The fix parses the result as if it would have been executed correctly. If the result is unparseable, the same behavior as it used to have it's kept.