### PR TITLE
:bug: Fixed `Cannot Assign To Read-Only Proprety '0' of object[array]`

### DIFF
--- a/src.ts/abi/fragments.ts
+++ b/src.ts/abi/fragments.ts
@@ -717,7 +717,7 @@ export class ParamType {
             }
             const childType = this.arrayChildren;
 
-            const result = value.slice();
+            const result = [...value]
             result.forEach((value, index) => {
                 childType.#walkAsync(promises, value, process, (value: any) => {
                     result[index] = value;
@@ -733,7 +733,7 @@ export class ParamType {
             // Convert the object into an array
             let result: Array<any>;
             if (Array.isArray(value)) {
-                result = value.slice();
+                result = [...value]
 
             } else {
                 if (value == null || typeof(value) !== "object") {


### PR DESCRIPTION
In the `fragments.ts` file under the abi dir, i was getting this error whilst sending a simple transaction which included 
arrays.

It was using ``.slice()`` to copy the array over - I switched it over to the spread operator. I'm not sure what is the performance/practical difference between the two, but it made it work.

![image](https://github.com/ethers-io/ethers.js/assets/102993172/d9b909a9-ac96-42ff-b959-53a330bdd2f6)
