### PR TITLE
Fix zero address check in lookupAddress()

### DIFF
--- a/src.ts/providers/abstract-provider.ts
+++ b/src.ts/providers/abstract-provider.ts
@@ -13,7 +13,7 @@
 //   of Signer/ENS name to address so we can sync respond to listenerCount.
 
 import { getAddress, resolveAddress } from "../address/index.js";
-import { ZeroHash } from "../constants/index.js";
+import { ZeroAddress } from "../constants/index.js";
 import { Contract } from "../contract/index.js";
 import { namehash } from "../hash/index.js";
 import { Transaction } from "../transaction/index.js";
@@ -985,7 +985,7 @@ export class AbstractProvider implements Provider {
             ], this);
 
             const resolver = await ensContract.resolver(node);
-            if (resolver == null || resolver === ZeroHash) { return null; }
+            if (resolver == null || resolver === ZeroAddress) { return null; }
 
             const resolverContract = new Contract(resolver, [
                 "function name(bytes32) view returns (string)"


### PR DESCRIPTION
Noticed earlier that we were sending `name(bytes32)` calls to the zero address.  I think it's due to this invalid comparison preventing this from returning early and saving a bunch of unnecessary RPC calls.