### PR TITLE
Update README.md to better reflect size of package

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ in [TypeScript](https://www.typescriptlang.org).
 - Meta-classes create JavaScript objects from any contract ABI, including **ABIv2** and **Human-Readable ABI**
 - Connect to Ethereum nodes over [JSON-RPC](https://github.com/ethereum/wiki/wiki/JSON-RPC), [INFURA](https://infura.io), [Etherscan](https://etherscan.io), [Alchemy](https://alchemyapi.io), [Ankr](https://ankr.com) or [MetaMask](https://metamask.io)
 - **ENS names** are first-class citizens; they can be used anywhere an Ethereum addresses can be used
-- **Tiny** (~120kb compressed; 400kb uncompressed)
+- **Small** (~120kb compressed; 400kb uncompressed)
 - **Tree-shaking** focused; include only what you need during bundling
 - **Complete** functionality for all your Ethereum desires
 - Extensive [documentation](https://docs.ethers.org/v6/)


### PR DESCRIPTION
Replace "Tiny" with "Small" to better reflect the package size for front-end web development.

The threshold for tiny is somewhere below 25kb uncompressed. I say this as someone concerned about page load speed and lighthouse scores and who commonly deploys sites that load _all_ assets totalling less than 100kb.

It would be better to use words that more closely align with the truth to give a better impression of the project.