### PR TITLE
Documentation: Fix typo in docs.wrm/migrating.wrm

### DIFF
--- a/docs.wrm/migrating.wrm
+++ b/docs.wrm/migrating.wrm
@@ -60,7 +60,7 @@ _code: simple comparison on large numbers  @lang<script>
   isEqual = value1.eq(value2)
 
   // Using BigInt in v6
-  isEqaul = (value1 == value2)
+  isEqual = (value1 == value2)
 
 
 _subsection: Contracts @<migrate-contracts>


### PR DESCRIPTION
https://docs.ethers.org/v6/migrating/ ->
![https___docs_ethers_org_v6_migrating_](https://github.com/ethers-io/ethers.js/assets/5952255/9262b835-0783-4fe4-b2ed-343962c553c5)
