### PR TITLE
Update getting-started.wrm

### DIFF
--- a/docs.wrm/getting-started.wrm
+++ b/docs.wrm/getting-started.wrm
@@ -11,7 +11,7 @@ If using NPM, you must first install Ethers.
 
 _code: installing via NPM @lang<shell>
   # Install ethers
-  /home/ricmoo/test-ethers> npm install ethers@beta-exports
+  /home/ricmoo/test-ethers> npm install ethers
 
 _null:
 
@@ -35,7 +35,7 @@ _code: importing in Node.js  @lang<script>
 
 _code: importing ESM in a browser  @lang<script>
   <script type="module">
-    import { ethers } from "https://cdnjs.cloudflare.com/ajax/libs/ethers/5.7.2/ethers.min.js";
+    import { ethers } from "https://cdnjs.cloudflare.com/ajax/libs/ethers/6.6.0/ethers.min.js";
     // Your code here...
   </script>
 


### PR DESCRIPTION
`npm install ethers` is already installing v6.

The v6.6.0 is on the CDN too.