### PR TITLE
typo: wieght -> weight

### DIFF
--- a/src.ts/providers/provider-fallback.ts
+++ b/src.ts/providers/provider-fallback.ts
@@ -398,7 +398,7 @@ export class FallbackProvider extends AbstractProvider {
         this.eventWorkers = 1;
 
         assertArgument(this.quorum <= this.#configs.reduce((a, c) => (a + c.weight), 0),
-            "quorum exceed provider wieght", "quorum", this.quorum);
+            "quorum exceed provider weight", "quorum", this.quorum);
     }
 
     get providerConfigs(): Array<FallbackProviderState> {


### PR DESCRIPTION
Small typo in an error I came across yesterday.