### PR TITLE
support encoding and decoding of function types

### DIFF
--- a/src.ts/abi/abi-coder.ts
+++ b/src.ts/abi/abi-coder.ts
@@ -144,6 +144,8 @@ export class AbiCoder {
                 return new StringCoder(param.name);
             case "bytes":
                 return new BytesCoder(param.name);
+            case "function":
+                return new FixedBytesCoder(24, param.name);
             case "":
                 return new NullCoder(param.name);
         }


### PR DESCRIPTION
Support encoding and decoding of function types. Fix part of the issue #389 

Remix IDE is using `ethers.js v5.7.2`. I wonder if @ricmoo  can release v5.7.3, so that Remix does not need to update to v6.