### PR TITLE
Fix encoding filter topics for `bytesX` param

### DIFF
--- a/src.ts/_tests/test-abi.ts
+++ b/src.ts/_tests/test-abi.ts
@@ -71,9 +71,54 @@ describe("Test Bytes32 strings", function() {
 });
 
 describe("Test Interface", function() {
+    const eventABI = {
+        anonymous: false,
+        inputs: [
+          {
+            indexed: true,
+            internalType: "bytes20",
+            name: "walletPubKeyHash",
+            type: "bytes20",
+          },
+          {
+            indexed: false,
+            internalType: "bytes",
+            name: "redeemerOutputScript",
+            type: "bytes",
+          },
+          {
+            indexed: true,
+            internalType: "address",
+            name: "redeemer",
+            type: "address",
+          },
+          {
+            indexed: false,
+            internalType: "uint64",
+            name: "requestedAmount",
+            type: "uint64",
+          },
+          {
+            indexed: false,
+            internalType: "uint64",
+            name: "treasuryFee",
+            type: "uint64",
+          },
+          {
+            indexed: false,
+            internalType: "uint64",
+            name: "txMaxFee",
+            type: "uint64",
+          },
+        ],
+        name: "RedemptionRequested",
+        type: "event",
+    };
+
     const iface = new Interface([
         "function balanceOf(address owner) returns (uint)",
-        "event Transfer(address indexed from, address indexed to, uint amount)"
+        "event Transfer(address indexed from, address indexed to, uint amount)",
+        eventABI,
     ]);
 
     it("does interface stuff; @TODO expand this", function() {
@@ -110,6 +155,17 @@ describe("Test Interface", function() {
         assert.equal(filter[0], "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef");
         assert.equal(filter[1], "0x0000000000000000000000008ba1f109551bd432803012645ac136ddd64dba72");
         assert.equal(filter[2], "0x000000000000000000000000ac1639cf97a3a46d431e6d1216f576622894cbb5");
+
+        // Data from:
+        // https://goerli.etherscan.io/tx/0xe61cef4cd706db8e23114717a207d76cc6b0df0b74ec52805551c4d1bf347a27#eventlog
+        // see `RedemptionRequested` event.
+        const walletPubKeyHash = "0x03b74d6893ad46dfdd01b9e0e3b3385f4fce2d1e"
+        const redeemer = "0x086813525A7dC7dafFf015Cdf03896Fd276eab60"
+        const filterWithBytes20 = iface.encodeFilterTopics("RedemptionRequested", [ walletPubKeyHash, undefined, redeemer ]);
+        assert.equal(filterWithBytes20.length, 3);
+        assert.equal(filterWithBytes20[0], "0x97a0199072f487232635d50ab75860891afe0b91c976ed2fc76502c4d82d0d95");
+        assert.equal(filterWithBytes20[1], "0x03b74d6893ad46dfdd01b9e0e3b3385f4fce2d1e000000000000000000000000");
+        assert.equal(filterWithBytes20[2], "0x000000000000000000000000086813525a7dc7dafff015cdf03896fd276eab60");
 
         const eventLog = iface.encodeEventLog("Transfer", [ addr, addr2, 234 ]);
         assert.equal(eventLog.data, "0x00000000000000000000000000000000000000000000000000000000000000ea");

--- a/src.ts/abi/interface.ts
+++ b/src.ts/abi/interface.ts
@@ -1023,6 +1023,8 @@ export class Interface {
                  return id(value);
             } else if (param.type === "bytes") {
                  return keccak256(hexlify(value));
+            } else if (param.type.match(/^bytes(\d+)$/)) {
+                return this.#abiCoder.encode([param.type], [value]);
             }
 
             if (param.type === "bool" && typeof(value) === "boolean") {


### PR DESCRIPTION
Based on the [Solidity docs](https://docs.soliditylang.org/en/v0.8.17/abi-spec.html#formal-specification-of-the-encoding) the `bytesX` param should be a sequence of bytes in X padded with trailing zero-bytes to a length of 32 bytes (right-padded). In the previous implementation, it was not possible to query events by indexed `bytesX` parameter due to invalid padding. Consider this `0x03b74d6893ad46dfdd01b9e0e3b3385f4fce2d1e` value as `bytes20`:
- before fix: `0x00000000000000000000000003b74d6893ad46dfdd01b9e0e3b3385f4fce2d1e`,
- after fix: `0x03b74d6893ad46dfdd01b9e0e3b3385f4fce2d1e000000000000000000000000`.

Example transaction:
https://goerli.etherscan.io/tx/0xe61cef4cd706db8e23114717a207d76cc6b0df0b74ec52805551c4d1bf347a27#eventlog see `RedemptionRequested` event and `bytes20 walletPubKeyHash` param.