### PR TITLE
Filter events with multiple addresses

### DIFF
--- a/src.ts/contract/contract.ts
+++ b/src.ts/contract/contract.ts
@@ -88,7 +88,12 @@ class PreparedTopicFilter implements DeferredTopicFilter {
 
                 return param.walkAsync(args[index], (type, value) => {
                     if (type === "address") {
-                        return resolveAddress(value, resolver);
+                        if (Array.isArray(value)) {
+                            return value.map((v) => resolveAddress(v, resolver));
+                        } else {
+                            return resolveAddress(value, resolver);
+                        }
+                        
                     }
                     return value;
                 });


### PR DESCRIPTION
When resolving addresses `PreparedTopicFilter` does not take into account that an input can be an array of addresses. This issue has already been described in https://github.com/ethers-io/ethers.js/issues/3831

In v5 it was possible to do something like:
```ts
contract.filters.Transfer(null, [address1, address2, address3])
```

In v6 it fails:
```ts
const eventFilter = contract.filters.Transfer(null, [address1, address2, address3])
await contract.queryFilter(eventFilter)

// Fails with "unsupported addressable value"
```

With this PR, when an input is and array of addresses `PreparedTopicFilter` returns an array of resolved addresses