### PR TITLE
Allow Contracts to have default override values

### DIFF
--- a/src.ts/_tests/test-contract.ts
+++ b/src.ts/_tests/test-contract.ts
@@ -37,6 +37,32 @@ describe("Test Contract", function() {
         assert.equal(await contract.testCallAdd(6, 0), BigInt(6), "testCallAdd(6, 0)");
     });
 
+    it("tests contract default overrides", async function() {
+        this.timeout(10000);
+
+        const provider = getProvider("InfuraProvider", "goerli");
+        const contract1 = new Contract(addr, abi, { provider }, {
+            _defaultOverrides: {
+                gasLimit: BigInt(9_999_999),
+                value: BigInt(1234567890)
+            }
+        });
+        const contract2 = new Contract(addr, abi, { provider }, {
+            _defaultOverrides: {
+                gasLimit: BigInt(2_222_222),
+                value: BigInt(9876543210)
+            }
+        });
+
+        const tx1 = await contract1.testCallAdd.populateTransaction(4, 5)
+        const tx2 = await contract2.testCallAdd.populateTransaction(4, 5)
+
+        assert.equal(tx1.gasLimit, BigInt(9_999_999), "contract1 default overrides gasLimit");
+        assert.equal(tx1.value, BigInt(1234567890), "contract1 default overrides value");
+        assert.equal(tx2.gasLimit, BigInt(2_222_222), "contract2 default overrides gasLimit");
+        assert.equal(tx2.value, BigInt(9876543210), "contract2 default overrides value");
+    });
+
     it("tests events", async function() {
         this.timeout(60000);
 

--- a/src.ts/_tests/test-contract.ts
+++ b/src.ts/_tests/test-contract.ts
@@ -55,12 +55,12 @@ describe("Test Contract", function() {
         });
 
         const tx1 = await contract1.testCallAdd.populateTransaction(4, 5)
-        const tx2 = await contract2.testCallAdd.populateTransaction(4, 5)
+        const tx2 = await contract2.testCallAdd.populateTransaction(4, 5, { value: BigInt(123) })
 
         assert.equal(tx1.gasLimit, BigInt(9_999_999), "contract1 default overrides gasLimit");
         assert.equal(tx1.value, BigInt(1234567890), "contract1 default overrides value");
         assert.equal(tx2.gasLimit, BigInt(2_222_222), "contract2 default overrides gasLimit");
-        assert.equal(tx2.value, BigInt(9876543210), "contract2 default overrides value");
+        assert.equal(tx2.value, BigInt(123), "contract2 default overrides value");
     });
 
     it("tests events", async function() {

--- a/src.ts/contract/contract.ts
+++ b/src.ts/contract/contract.ts
@@ -31,8 +31,8 @@ import type {
     ContractEvent,
     ContractTransaction,
     DeferredTopicFilter,
-    WrappedFallback
-} from "./types.js";
+    WrappedFallback, Overrides,
+} from './types.js'
 
 const BN_0 = BigInt(0);
 
@@ -250,6 +250,7 @@ function buildWrappedFallback(contract: BaseContract): WrappedFallback {
 }
 
 function buildWrappedMethod<A extends Array<any> = Array<any>, R = any, D extends R | ContractTransactionResponse = ContractTransactionResponse>(contract: BaseContract, key: string): BaseContractMethod<A, R, D> {
+    const defaultOverrides = getInternal(contract).defaultOverrides;
 
     const getFragment = function(...args: ContractMethodArgs<A>): FunctionFragment {
         const fragment = contract.interface.getFunction(key, args);
@@ -264,9 +265,9 @@ function buildWrappedMethod<A extends Array<any> = Array<any>, R = any, D extend
         const fragment = getFragment(...args);
 
         // If an overrides was passed in, copy it and normalize the values
-        let overrides: Omit<ContractTransaction, "data" | "to"> = { };
+        let overrides: Omit<ContractTransaction, "data" | "to"> = await copyOverrides(defaultOverrides);
         if (fragment.inputs.length + 1 === args.length) {
-            overrides = await copyOverrides(args.pop());
+            overrides = Object.assign({}, defaultOverrides, await copyOverrides(args.pop()));
         }
 
         if (fragment.inputs.length !== args.length) {
@@ -426,6 +427,8 @@ type Internal = {
     deployTx: null | ContractTransactionResponse;
 
     subs: Map<string, Sub>;
+
+    defaultOverrides: null | Overrides;
 };
 
 const internalValues: WeakMap<BaseContract, Internal> = new WeakMap();
@@ -664,9 +667,21 @@ export class BaseContract implements Addressable, EventEmitterable<ContractEvent
      *  optionally connected to a %%runner%% to perform operations on behalf
      *  of.
      */
-    constructor(target: string | Addressable, abi: Interface | InterfaceAbi, runner?: null | ContractRunner, _deployTx?: null | TransactionResponse) {
+    constructor(target: string | Addressable, abi: Interface | InterfaceAbi, runner?: null | ContractRunner, _deployTx?: null | TransactionResponse, _defaultOverrides?: null | Overrides)
+    constructor(target: string | Addressable, abi: Interface | InterfaceAbi, runner?: null | ContractRunner, _opts?: { _deployTx?: null | TransactionResponse, _defaultOverrides?: null | Overrides })
+    constructor(target: string | Addressable, abi: Interface | InterfaceAbi, runner?: null | ContractRunner , _optsOrDeployTx?: null | TransactionResponse| { _deployTx?: null | TransactionResponse, _defaultOverrides?: null | Overrides }, _defaultOverrides?: null | Overrides) {
         assertArgument(typeof(target) === "string" || isAddressable(target),
             "invalid value for Contract target", "target", target);
+
+        let _deployTx: null | TransactionResponse = null;
+        if (_optsOrDeployTx && typeof _optsOrDeployTx === "object") {
+            if ("_deployTx" in _optsOrDeployTx) {
+                _deployTx = _optsOrDeployTx._deployTx ?? _deployTx;
+            }
+            if ("_defaultOverrides" in _optsOrDeployTx) {
+                _defaultOverrides = _optsOrDeployTx._defaultOverrides ?? _defaultOverrides;
+            }
+        }
 
         if (runner == null) { runner = null; }
         const iface = Interface.from(abi);
@@ -683,6 +698,11 @@ export class BaseContract implements Addressable, EventEmitterable<ContractEvent
             // @TODO: the provider can be null; make a custom dummy provider that will throw a
             // meaningful error
             deployTx = new ContractTransactionResponse(this.interface, <Provider>provider, _deployTx);
+        }
+
+        let defaultOverrides: null | Overrides = null;
+        if (_defaultOverrides) {
+            defaultOverrides = Object.assign({}, _defaultOverrides);
         }
 
         let subs = new Map();
@@ -720,7 +740,7 @@ export class BaseContract implements Addressable, EventEmitterable<ContractEvent
         }
 
         // Set our private values
-        setInternal(this, { addrPromise, addr, deployTx, subs });
+        setInternal(this, { addrPromise, addr, deployTx, subs, defaultOverrides });
 
         // Add the event filters
         const filters = new Proxy({ }, {
@@ -854,6 +874,16 @@ export class BaseContract implements Addressable, EventEmitterable<ContractEvent
      */
     deploymentTransaction(): null | ContractTransactionResponse {
         return getInternal(this).deployTx;
+    }
+
+    /**
+     *  Return the transaction used to deploy this contract.
+     *
+     *  This is only available if this instance was returned from a
+     *  [[ContractFactory]].
+     */
+    defaultOverrides(): null | Overrides {
+        return getInternal(this).defaultOverrides;
     }
 
     /**
@@ -1068,7 +1098,7 @@ export class BaseContract implements Addressable, EventEmitterable<ContractEvent
     }
 }
 
-function _ContractBase(): new (target: string, abi: Interface | InterfaceAbi, runner?: null | ContractRunner) => BaseContract & Omit<ContractInterface, keyof BaseContract> {
+function _ContractBase(): new (target: string, abi: Interface | InterfaceAbi, runner?: null | ContractRunner, _opts?: { _defaultOverrides?: null | Overrides }) => BaseContract & Omit<ContractInterface, keyof BaseContract> {
     return BaseContract as any;
 }
 


### PR DESCRIPTION
* save default `Overrides` when constructing a new `Contract` instance
* use default overrides on `populateTransaction` call