### PR TITLE
Add providerType() getter to AbstractProvider

### DIFF
--- a/src.ts/providers/abstract-provider.ts
+++ b/src.ts/providers/abstract-provider.ts
@@ -428,6 +428,8 @@ type CcipArgs = {
     errorArgs: Array<any>
 };
 
+type ProviderType = "jsonrpc" | "etherscan" | "fallback" | "";
+
 /**
  *  An **AbstractProvider** provides a base class for other sub-classes to
  *  implement the [[Provider]] API by normalizing input arguments and
@@ -503,6 +505,17 @@ export class AbstractProvider implements Provider {
      *  the [[ContractRunner]] interface.
      */
     get provider(): this { return this; }
+
+    /**
+     *  Returns a string that identifies the AbstractProvider subclass, for
+     *  better duck typing.
+     */
+    get providerType(): ProviderType {
+        assert(false, "not implemented yet", "NOT_IMPLEMENTED", {
+            operation: "providerType"
+        });
+        return "";
+    }
 
     /**
      *  Returns all the registered plug-ins.

--- a/src.ts/providers/provider-etherscan.ts
+++ b/src.ts/providers/provider-etherscan.ts
@@ -142,6 +142,10 @@ export class EtherscanProvider extends AbstractProvider {
         this.getBaseUrl();
     }
 
+    get providerType() {
+        return 'etherscan' as const;
+    }
+
     /**
      *  Returns the base URL.
      *

--- a/src.ts/providers/provider-fallback.ts
+++ b/src.ts/providers/provider-fallback.ts
@@ -414,6 +414,10 @@ export class FallbackProvider extends AbstractProvider {
             "quorum exceed provider wieght", "quorum", this.quorum);
     }
 
+    get providerType() {
+        return 'fallback' as const;
+    }
+
     get providerConfigs(): Array<FallbackProviderState> {
         return this.#configs.map((c) => {
             const result: any = Object.assign({ }, c);

--- a/src.ts/providers/provider-jsonrpc.ts
+++ b/src.ts/providers/provider-jsonrpc.ts
@@ -572,6 +572,10 @@ export abstract class JsonRpcApiProvider extends AbstractProvider {
         }
     }
 
+    get providerType() {
+        return 'jsonrpc' as const;
+    }
+
     /**
      *  Returns the value associated with the option %%key%%.
      *


### PR DESCRIPTION
This PR is just a suggestion.

## Context

In [Railgun engine](https://github.com/Railgun-Community/engine/blob/ab596e14d7e78476c98abd54facff912342b0384/src/provider/polling-util.ts#L33), there is a need to know what kind of provider is received: FallbackProvider or JsonRpc?

## Problem

`instanceof` is a brittle way of distinguishing subclass types, because if we happen to have two different versions of ethers installed (suppose a transitive dependency has version `1.2.3` while we have version `1.3.0`), then `JsonRpcProvider` from version 1.2.3 will **not** pass the `instanceof` test if the right-hand side is `JsonRpcProvider` from version 1.3.0.

## Solution

Use duck typing. We could do that by looking for the presence of specific methods that only exist in `JsonRpcProvider`, but this is also brittle as the library gets updated.

So we add a new getter function `providerType()` which only answers the subclass type. 