### PR TITLE
Add Tenderly provider

### DIFF
--- a/docs.wrm/links/projects.txt
+++ b/docs.wrm/links/projects.txt
@@ -21,6 +21,7 @@ link-react-native [React Native](https://reactnative.dev)
 link-semver [semver](https://semver.org)
 link-solidity [Solidity](https://solidity.readthedocs.io/)
 link-tally [Tally](https://tallyho.org)
+link-tenderly [Tenderly](https://tenderly.co?utm_source=ethers)
 
 # Project-specific
 link-alchemy-signup [Alchemy Signup](https://dashboard.alchemyapi.io/signup?referral=55a35117-028e-4b7c-9e47-e275ad0acc6d)
@@ -35,6 +36,7 @@ link-infura-secret [link-infura-secret](https://infura.io/docs/gettingStarted/au
 link-parity-trace [link-parity-trace](https://openethereum.github.io/wiki/JSONRPC-trace-module)
 link-parity-rpc [link-parity-rpc](https://openethereum.github.io/wiki/JSONRPC)
 link-pocket-signup [link-pocket-signup](https://pokt.network/pocket-gateway-ethereum-mainnet/)
+link-tenderly-signup [link-tenderly-signup](https://dashboard.tenderly.co/register?utm_source=ethers)
 link-web3js [link-web3](https://github.com/ethereum/web3.js)
 link-web3-http [link-web3-http](https://github.com/ethereum/web3.js/tree/1.x/packages/web3-providers-http)
 link-web3-ipc [link-web3-ipc](https://github.com/ethereum/web3.js/tree/1.x/packages/web3-providers-ipc)

--- a/src.ts/_tests/create-provider.ts
+++ b/src.ts/_tests/create-provider.ts
@@ -6,6 +6,7 @@ import {
     InfuraProvider,
 //    PocketProvider,
     QuickNodeProvider,
+    TenderlyProvider,
 
     FallbackProvider,
     isError,
@@ -86,11 +87,18 @@ const ProviderCreators: Array<ProviderCreator> = [
         }
     },
     {
+        name: "TenderlyProvider",
+        networks: ethNetworks,
+        create: function(network: string) {
+            return new TenderlyProvider(network);
+        }
+    },
+    {
         name: "FallbackProvider",
         networks: ethNetworks,
         create: function(network: string) {
             const providers: Array<AbstractProvider> = [];
-            for (const providerName of [ "AlchemyProvider", "AnkrProvider", "EtherscanProvider", "InfuraProvider" ]) {
+            for (const providerName of [ "AlchemyProvider", "AnkrProvider", "EtherscanProvider", "InfuraProvider", "TenderlyProvider" ]) {
                 const provider = getProvider(providerName, network);
                 if (provider) { providers.push(provider); }
             }

--- a/src.ts/_tests/test-providers-data.ts
+++ b/src.ts/_tests/test-providers-data.ts
@@ -207,7 +207,7 @@ describe("Test Provider Transaction operations", function() {
 
             // Cloudflare doesn't return the root in legacy receipts; but it isn't
             // *actually* that important, so we'll give it a pass...
-            if (providerName === "CloudflareProvider" || providerName === "AnkrProvider" || providerName === "PocketProvider") {
+            if (providerName === "CloudflareProvider" || providerName === "AnkrProvider" || providerName === "PocketProvider" || providerName === "TenderlyProvider") {
                 test = Object.assign({ } , test, { root: undefined });
             }
 

--- a/src.ts/ethers.ts
+++ b/src.ts/ethers.ts
@@ -71,6 +71,7 @@ export {
 
     AlchemyProvider, AnkrProvider, CloudflareProvider, EtherscanProvider,
     InfuraProvider, InfuraWebSocketProvider, PocketProvider, QuickNodeProvider,
+    TenderlyProvider,
 
     IpcSocketProvider, SocketProvider, WebSocketProvider,
 

--- a/src.ts/providers/default-provider.ts
+++ b/src.ts/providers/default-provider.ts
@@ -8,6 +8,7 @@ import { EtherscanProvider } from "./provider-etherscan.js";
 import { InfuraProvider } from "./provider-infura.js";
 //import { PocketProvider } from "./provider-pocket.js";
 import { QuickNodeProvider } from "./provider-quicknode.js";
+import { TenderlyProvider } from "./provider-tenderly.js";
 
 import { FallbackProvider } from "./provider-fallback.js";
 import { JsonRpcProvider } from "./provider-jsonrpc.js";
@@ -83,6 +84,12 @@ export function getDefaultProvider(network: string | Networkish | WebSocketLike,
     if (allowService("etherscan")) {
         try {
             providers.push(new EtherscanProvider(network, options.etherscan));
+        } catch (error) { }
+    }
+
+    if (allowService("tenderly")) {
+        try {
+            providers.push(new TenderlyProvider(network, options.tenderly));
         } catch (error) { }
     }
 

--- a/src.ts/providers/index.ts
+++ b/src.ts/providers/index.ts
@@ -66,6 +66,7 @@ export { EtherscanProvider, EtherscanPlugin } from "./provider-etherscan.js";
 export { InfuraProvider, InfuraWebSocketProvider } from "./provider-infura.js";
 export { PocketProvider } from "./provider-pocket.js";
 export { QuickNodeProvider } from "./provider-quicknode.js";
+export { TenderlyProvider } from "./provider-tenderly";
 
 import { IpcSocketProvider } from "./provider-ipcsocket.js"; /*-browser*/
 export { IpcSocketProvider };

--- a/src.ts/providers/provider-tenderly.ts
+++ b/src.ts/providers/provider-tenderly.ts
@@ -1,0 +1,130 @@
+/**
+ *  [[link-tenderly]] provides a third-party service for connecting to
+ *  various blockchains over JSON-RPC.
+ *
+ *  **Supported Networks**
+ *
+ *  - Ethereum Mainnet (``mainnet``)
+ *  - Goerli Testnet (``goerli``)
+ *  - Sepolia Testnet (``sepolia``)
+ *  - Polygon Mainnet (``polygon``)
+ *  - Polygon Mumbai Testnet (``polygon-mumbai``)
+ *  - Optimism Mainnet (``optimism``)
+ *  - Optimism Goerli Testnet (``optimism-goerli``)
+ *  - Base Mainnet (``base``)
+ *  - Base Goerli Testnet (``base-goerli``)
+ *  - Boba Ethereum (``boba-ethereum``)
+ *  - Boba BNB (``boba-bnb``)
+ *  - Boba BNB Testnet (``boba-bnb-testnet``)
+ *
+ *  @_subsection: api/providers/thirdparty:Tenderly  [providers-tenderly]
+ */
+import {
+    defineProperties, FetchRequest, assertArgument
+} from "../utils/index.js";
+
+import { showThrottleMessage } from "./community.js";
+import { Network } from "./network.js";
+import { JsonRpcProvider } from "./provider-jsonrpc.js";
+
+import type { AbstractProvider } from "./abstract-provider.js";
+import type { CommunityResourcable } from "./community.js";
+import type { Networkish } from "./network.js";
+
+
+const defaultApiKey = "";
+
+function getHost(name: string): string {
+    switch(name) {
+        case "mainnet":
+            return "mainnet.gateway.tenderly.co";
+        case "goerli":
+            return "goerli.gateway.tenderly.co";
+        case "sepolia":
+            return "sepolia.gateway.tenderly.co";
+        case "polygon":
+            return "polygon.gateway.tenderly.co";
+        case "polygon-mumbai":
+            return "polygon-mumbai.gateway.tenderly.co";
+        case "optimism":
+            return "optimism.gateway.tenderly.co";
+        case "optimism-goerli":
+            return "optimism-goerli.gateway.tenderly.co";
+        case "base":
+            return "base.gateway.tenderly.co";
+        case "base-goerli":
+            return "base-goerli.gateway.tenderly.co";
+        case "boba-ethereum":
+            return "boba-ethereum.gateway.tenderly.co";
+        case "boba-bnb":
+            return "boba-bnb.gateway.tenderly.co";
+        case "boba-bnb-testnet":
+            return "boba-bnb-testnet.gateway.tenderly.co";
+    }
+
+    assertArgument(false, "unsupported network", "network", name);
+}
+
+/**
+ *  The **TenderlyProvider** connects to the [[link-tenderly]]
+ *  JSON-RPC end-points.
+ *
+ *  By default, a highly-throttled API key is used, which is
+ *  appropriate for quick prototypes and simple scripts. To
+ *  gain access to an increased rate-limit, it is highly
+ *  recommended to [sign up here](link-tenderly-signup).
+ */
+export class TenderlyProvider extends JsonRpcProvider implements CommunityResourcable {
+    /**
+     *  The API key for the Tenderly connection.
+     */
+    readonly apiKey!: string;
+
+    /**
+     *  Create a new **TenderlyProvider**.
+     *
+     *  By default connecting to ``mainnet`` with a highly throttled
+     *  API key.
+     */
+    constructor(_network?: Networkish, apiKey?: null | string) {
+        if (_network == null) { _network = "mainnet"; }
+        const network = Network.from(_network);
+        if (apiKey == null) { apiKey = defaultApiKey; }
+
+        const request = TenderlyProvider.getRequest(network, apiKey);
+        super(request, network, { staticNetwork: network });
+
+        defineProperties<TenderlyProvider>(this, { apiKey });
+    }
+
+    _getProvider(chainId: number): AbstractProvider {
+        try {
+            return new TenderlyProvider(chainId, this.apiKey);
+        } catch (error) { }
+        return super._getProvider(chainId);
+    }
+
+    isCommunityResource(): boolean {
+        return (this.apiKey === defaultApiKey);
+    }
+
+    /**
+     *  Returns a prepared request for connecting to %%network%% with
+     *  %%apiKey%%.
+     */
+    static getRequest(network: Network, apiKey?: string): FetchRequest {
+        if (apiKey == null) { apiKey = defaultApiKey; }
+
+        const request = new FetchRequest(`https:/\/${ getHost(network.name) }/${ apiKey }`);
+        request.allowGzip = true;
+
+        if (apiKey === defaultApiKey) {
+            request.retryFunc = async (request, response, attempt) => {
+                showThrottleMessage("TenderlyProvider");
+                return true;
+            }
+        }
+
+        return request;
+    }
+}


### PR DESCRIPTION
## Description

Added [Tenderly Node](https://tenderly.co/web3-gateway) provider with supported RPC endpoints. The full list of supported networks can be found in the [official documentation](https://docs.tenderly.co/supported-networks-and-languages).

@ricmoo Do I need to run a build command since it will generate a lot of commonjs, esm and other files or you are doing it before releasing the new `ethers` version?

<img width="587" alt="image" src="https://github.com/ethers-io/ethers.js/assets/26412515/0f10d757-7961-46ce-9544-62e35c566746">