### PR TITLE
Add Node.js httpAgent for FetchRequest options to enable proxy support

### DIFF
--- a/src.ts/utils/fetch.ts
+++ b/src.ts/utils/fetch.ts
@@ -22,6 +22,7 @@ import { hexlify } from "./data.js";
 import { assert, assertArgument } from "./errors.js";
 import { defineProperties } from "./properties.js";
 import { toUtf8Bytes, toUtf8String } from "./utf8.js"
+import type { Agent } from 'http';
 
 import { getUrl } from "./geturl.js";
 
@@ -198,6 +199,7 @@ export class FetchRequest implements Iterable<[ key: string, value: string ]> {
     #retry?: null | FetchRetryFunc;
 
     #signal?: FetchCancelSignal;
+    #agent?: null | Agent;
 
     #throttle: Required<FetchThrottleParams>;
 
@@ -320,6 +322,14 @@ export class FetchRequest implements Iterable<[ key: string, value: string ]> {
      */
     clearHeaders(): void {
         this.#headers = { };
+    }
+
+    /**
+     *  Get the current httpAgent ( Node.js only )
+     */
+    get agent(): Agent | null { return this.#agent || null; }
+    set agent(_agent: Agent | null) {
+        this.#agent = _agent;
     }
 
     [Symbol.iterator](): Iterator<[ key: string, value: string ]> {

--- a/src.ts/utils/geturl.ts
+++ b/src.ts/utils/geturl.ts
@@ -28,6 +28,8 @@ export async function getUrl(req: FetchRequest, signal?: FetchCancelSignal): Pro
 
     const options: any = { method, headers };
 
+    if (req.agent && req.agent !== null) { options.agent = req.agent; };
+
     const request = ((protocol === "http") ? http: https).request(req.url, options);
 
     request.setTimeout(req.timeout);


### PR DESCRIPTION
supersedes #2829

This is the PR to add an option for FetchRequest so that mimicking registerGetUrl function to only use proxies are no longer required ( See https://github.com/ethers-io/ethers.js/discussions/4336 for the example code of it )

It will reduce needs for TypeScript projects to import and create bloat of types to fulfil the mimicked registerGetUrl function.

In short, only the following code will be required to use proxy connections

```js
const { JsonRpcProvider, FetchRequest } = require('ethers');
const { HttpsProxyAgent } = require('https-proxy-agent');

const fetchReq = new FetchRequest(RPC_URL_HERE);
fetchReq.agent = new HttpsProxyAgent(PROXY_URL_HERE);
const provider = new JsonRpcProvider(fetchReq);

provider.getBlockNumber().then(console.log)
```

Without this PR, you may try this

```js
const { ethers, JsonRpcProvider, FetchRequest } = require('ethers');
const fetch = require('cross-fetch');
const { HttpsProxyAgent } = require('https-proxy-agent');
const http = require('node:http');
const { createProxy } = require('proxy');

const ETH_RPC = 'https://eth.llamarpc.com';
// Example that doesn't use proxy connections
const BSC_RPC = 'https://binance.llamarpc.com';

const HTTP_PROXY_PORT = 3128;
const HTTP_PROXY_HOST = 'localhost';
const HTTP_PROXY = `http://${HTTP_PROXY_HOST}:${HTTP_PROXY_PORT}`;

/**
 * Define our own custom getUrl (typeof FetchGetUrlFunc) function
 *
 * See examples on
 * https://github.com/ethers-io/ethers.js/blob/main/src.ts/utils/geturl-browser.ts
 *
 * Documents:
 * https://docs.ethers.org/v6/api/utils/fetching/#FetchRequest_registerGetUrl
 * https://docs.ethers.org/v6/api/utils/fetching/#FetchGetUrlFunc
 */
const getUrl = async (req, _signal) => {
  // Inherited from https://github.com/ethers-io/ethers.js/blob/main/src.ts/utils/geturl-browser.ts
  let signal;

  if (_signal) {
      const controller = new AbortController();
      signal = controller.signal;
      _signal.addListener(() => { controller.abort(); });
  }

  const init = {
    method: req.method,
    headers: req.headers,
    body: req.body || undefined,
    signal
  };

  // This is what we want
  init.agent = new HttpsProxyAgent(HTTP_PROXY);

  // Inherited from https://github.com/ethers-io/ethers.js/blob/main/src.ts/utils/geturl-browser.ts
  const resp = await fetch(req.url, init);

  const headers = {};
  resp.headers.forEach((value, key) => {
    headers[key.toLowerCase()] = value;
  });

  const respBody = await resp.arrayBuffer();
  const body = (respBody == null) ? null: new Uint8Array(respBody);

  return {
    statusCode: resp.status,
    statusMessage: resp.statusText,
    headers,
    body
  };
};

/**
 * Define new FetchRequest used for a provider
 */
// Assigning custom getUrl function will apply to all ethers v6 providers

const fetchReq = new FetchRequest(ETH_RPC);
fetchReq.getUrlFunc = getUrl;
const provider = new JsonRpcProvider(fetchReq);
const provider2 = new JsonRpcProvider(BSC_RPC);

let resolvePromise;
const promise = new Promise((resolve) => {resolvePromise = resolve});

promise.then(() => provider.getBlockNumber().then(console.log));
promise.then(() => provider2.getBlockNumber().then(console.log));

/**
 * (Optional) Define new http proxy server to demonstrate RPC proxy connection (like squid)
 */
const server = createProxy(http.createServer());

server.listen(3128, () => {
  resolvePromise();
  console.log('HTTP(s) proxy server listening on port %d', server.address().port);
});

server.on('connect', (res, socket) => {
  // This is where you could find out that ethers provider will connect RPC via proxy agent
  console.log(`Proxy connection from ${socket.remoteAddress} with headers: ${JSON.stringify(res.rawHeaders)}`);
});
```