### PR TITLE
feat: add lachain network

### DIFF
--- a/src.ts/providers/network.ts
+++ b/src.ts/providers/network.ts
@@ -447,4 +447,6 @@ function injectCommonNetworks(): void {
     registerEth("optimism-goerli", 420, { });
 
     registerEth("xdai", 100, { ensNetwork: 1 });
+
+    registerEth("LaChain", 274, { });
 }


### PR DESCRIPTION
Add LaChain as network so the method `ethers.provider.getNetwork() `can return its name.