### PR TITLE
Change wrong docs

### DIFF
--- a/docs.wrm/migrating.wrm
+++ b/docs.wrm/migrating.wrm
@@ -353,8 +353,8 @@ _code: solidity non-standard packed  @lang<script>
 
   // v6
   ethers.solidityPacked(types, values)
-  ethers.utils.solidityPackedKeccak256(types, values)
-  ethers.utils.solidityPackedSha256(types, values)
+  ethers.solidityPackedKeccak256(types, values)
+  ethers.solidityPackedSha256(types, values)
 
 _code: property manipulation  @lang<script>
   // v5


### PR DESCRIPTION
On migration to v6 i was wondering to know where's the `solidityKeccak256` then i'd open the docs and found this

<img width="863" alt="image" src="https://github.com/ethers-io/ethers.js/assets/50513263/06e7dc5f-7d90-4795-b6cb-b2017b00e115">

but it's not working so i've changed to `ethers.solidityPackedKeccak256` and it's works fine

<img width="631" alt="image" src="https://github.com/ethers-io/ethers.js/assets/50513263/9d006442-140e-43ec-a063-fc41794736f9">
