### PR TITLE
Fix FallbackProvider getAnyResult() with errors

### DIFF
--- a/src.ts/providers/provider-fallback.ts
+++ b/src.ts/providers/provider-fallback.ts
@@ -305,6 +305,11 @@ function getAnyResult(quorum: number, results: Array<TallyResult>): undefined | 
     const result = checkQuorum(quorum, results);
     if (result !== undefined) { return result; }
 
+    // Otherwise, do we have any non-error result?
+    for (const r of results) {
+        if (r.value && !r.value.error) { return r.value; }
+    }
+
     // Otherwise, do we have any result?
     for (const r of results) {
         if (r.value) { return r.value; }


### PR DESCRIPTION
## Problem

When submitting a transaction (i.e. `broadcastTransaction`) with a FallbackProvider with 3 sub-providers (each with weight 2) and a quorum configured at `3`, the `_perform` will use `getAnyResult` to pluck the result from each of the sub-providers.

The way `getAnyResult` works (especially when `checkQuorum` is not used due to weights being smaller than the quorum number), means that it will pick the **first** result, regardless if it's an error or not.

In the context of broadcasting transactions, there are cases where one provider gets the transaction request, while other providers that are slower will error with `"already known"`, which in turn causes Ethers to produce

```
Error: could not coalesce error (error={ "code": -32000, "message": "already known" }
```

See issue https://github.com/ethers-io/ethers.js/issues/4186

<img width="876" alt="Screenshot 2023-10-30 at 12 41 37" src="https://github.com/ethers-io/ethers.js/assets/90512/5b78a3ef-1a81-42cd-9a42-a44095cefd21">


## Solution

In `getAnyResult`, give preference to early-returning non-error results.

<img width="911" alt="Screenshot 2023-10-30 at 13 28 31" src="https://github.com/ethers-io/ethers.js/assets/90512/9e438c11-258f-4b31-bad4-a77396c48c8b">
