### PR TITLE
Fix Interface.parseLog Typings

### DIFF
--- a/src.ts/abi/interface.ts
+++ b/src.ts/abi/interface.ts
@@ -1212,7 +1212,7 @@ export class Interface {
      *
      *  If the matching event cannot be found, returns null.
      */
-    parseLog(log: { topics: Array<string>, data: string}): null | LogDescription {
+    parseLog(log: { topics: ReadonlyArray<string>, data: string}): null | LogDescription {
         const fragment = this.getEvent(log.topics[0]);
 
         if (!fragment || fragment.anonymous) { return null; }


### PR DESCRIPTION
Fixes https://github.com/ethers-io/ethers.js/issues/4029

This PR fixes typings of the `parseLog` function. Specifically, `parseLog` doesn't work with the `Log`s that you receive from various `ethers` methods (logs in transaction receipts, when doing an `eth_getLogs`, etc.).

The typing issue is fairly straight forward, the `parseLog` function expects topics to be a `string[]`, but the `Log.topics` field is a `readonly string[]`. This causes some annoying TypeScript compile issues:

```ts
import { Interface, Log } from "ethers";

declare let log: Log;
declare let iface: Interface;
iface.parseLog(log)
```

```
error TS2345: Argument of type 'Log' is not assignable to parameter of type '{ topics: string[]; data: string; }'.
  Types of property 'topics' are incompatible.
    The type 'readonly string[]' is 'readonly' and cannot be assigned to the mutable type 'string[]'.

5 iface.parseLog(log)
                 ~~~
```

Fortunately, `parseLog` doesn't need `topics` to be mutable, so the fix is fairly straight-forward.