### PR TITLE
Fetch priorityFeePerGas in a native way for merge  and optimism chains

### DIFF
--- a/src.ts/providers/provider-jsonrpc.ts
+++ b/src.ts/providers/provider-jsonrpc.ts
@@ -793,6 +793,9 @@ export abstract class JsonRpcApiProvider extends AbstractProvider {
             case "getGasPrice":
                 return { method: "eth_gasPrice", args: [] };
 
+            case "getPriorityFeePerGas":
+                return { method: "eth_maxPriorityFeePerGas", args: [] };
+
             case "getBalance":
                 return {
                     method: "eth_getBalance",


### PR DESCRIPTION
closes #4363

This patch doesn't break with chains that doesn't support the method `eth_maxPriorityFeePerGas` and will fallback to 1 Gwei as per supported.

This patch is a must since supporting transactions less than 1 Gwei is now crucial given the growth of the recent L2 chains.

The method was supported since from the beginning of the EIP-1559 https://github.com/ethereum/go-ethereum/commit/5cff9754d795971451f2f4e8a2cc0c6f51ce9802#diff-743816a1d619b592f395ca0641e2f96df78708f35726f1099da4696a1a9384a0 and I think since this patch doesn't break with non EIP-1559 chains I think it should be merged.

Otherwise, we will be adding a long list of growing L2 chains https://l2beat.com/scaling/summary every time.