### PR TITLE
Fix for ENSIP-10 wildcard resolution

### DIFF
--- a/src.ts/providers/ens-resolver.ts
+++ b/src.ts/providers/ens-resolver.ts
@@ -236,6 +236,7 @@ export class EnsResolver {
             ];
 
             funcName = "resolve(bytes,bytes)";
+            fragment = null;
         }
 
         params.push({


### PR DESCRIPTION
The current code attempts to decode the response body twice resulting in the below error:

<img width="1428" alt="ethers-double-decode-error" src="https://github.com/ethers-io/ethers.js/assets/4473177/0653c41c-75ff-4bc0-8876-25ba03cf2e76">

This fix prevents the second attempted decode.

Reproduction:
```
const sepoliaProvider =  new ethers.JsonRpcProvider("https://eth-sepolia.g.alchemy.com/v2/API-KEY");
await sepoliaProvider.resolveName("hi.demoname.eth");
```
