### PR TITLE
Add timeout param to ContractTransactionResponse#wait

### DIFF
--- a/src.ts/contract/wrappers.ts
+++ b/src.ts/contract/wrappers.ts
@@ -132,8 +132,8 @@ export class ContractTransactionResponse extends TransactionResponse {
      *  and the transaction has not been mined, otherwise this will
      *  wait until enough confirmations have completed.
      */
-    async wait(confirms?: number): Promise<null | ContractTransactionReceipt> {
-        const receipt = await super.wait(confirms);
+    async wait(confirms?: number, timeout?: number): Promise<null | ContractTransactionReceipt> {
+        const receipt = await super.wait(confirms, timeout);
         if (receipt == null) { return null; }
         return new ContractTransactionReceipt(this.#iface, this.provider, receipt);
     }


### PR DESCRIPTION
From the function documentation, it appears that ContractTransactionResponse#wait was meant to include support for a timeout, but the parameter is missing.

This PR adds the optional timeout parameter to the function.