### PR TITLE
Improve getDefaultProvider types

### DIFF
--- a/src.ts/providers/default-provider.ts
+++ b/src.ts/providers/default-provider.ts
@@ -68,7 +68,7 @@ const Testnets = "goerli kovan sepolia classicKotti optimism-goerli arbitrum-goe
  *      exclusive: [ "etherscan", "infura" ]
  *    });
  */
-export function getDefaultProvider(network: string | Networkish | WebSocketLike, options?: any): AbstractProvider {
+export function getDefaultProvider(network?: string | Networkish | WebSocketLike, options?: any): AbstractProvider {
     if (options == null) { options = { }; }
 
     const allowService = (name: string) => {


### PR DESCRIPTION
I'm using ethers + typescript and I'm forced to call the provider this way:

```typescript
const provider = ethers.getDefaultProvider(null as unknown as string)
```

The problem is that getDefaultProvider types require passing a first argument, although in fact it is optional. As a result, I have to cheat with typescript just to run the code. I add just one character to the codebase and the first argument becomes optional, which it really is. This seems to improve the development experience, take a look at the new code:

```typescript
const provider = ethers.getDefaultProvider()
```
