### PR TITLE
Fix discarded hex zeroes in toBeArray method

### DIFF
--- a/src.ts/utils/maths.ts
+++ b/src.ts/utils/maths.ts
@@ -209,12 +209,24 @@ export function toBeHex(_value: BigNumberish, _width?: Numeric): string {
  *  Converts %%value%% to a Big Endian Uint8Array.
  */
 export function toBeArray(_value: BigNumberish): Uint8Array {
+    let leftPadZeroCount = 0;
+    if (typeof _value === "string") {
+        _value = _value.replace("0x", "");
+        for (let i = 0; i < _value.length; i++) {
+            if (_value[i] === "0") {
+                leftPadZeroCount++;
+            } else {
+                break;
+            }
+        }
+    }
+
     const value = getUint(_value, "value");
 
     if (value === BN_0) { return new Uint8Array([ ]); }
 
     let hex = value.toString(16);
-    if (hex.length % 2) { hex = "0" + hex; }
+    hex = "0".repeat(leftPadZeroCount) + hex
 
     const result = new Uint8Array(hex.length / 2);
     for (let i = 0; i < result.length; i++) {


### PR DESCRIPTION
Previously, due to converting to BigInt before converting to Uint8Array, the zero bytes on hex string values were lost ("0x0011" => 18 => "0x11"). This PR fixes the issue by re-adding left-padded zero bytes to the Uint8Array.

I discovered this bug in a scenario where I was recovering the address of a signature. I created a packed keccak256 hash and converted it to Uint8Array. Then I tried to recover the address, but the address was wrong. After some debugging, I noticed that the generated message hash is `0x005621...`. And I checked the size of the Uint8Array, and it was 31 bytes. And this caused `verifyMessage` function to recover a wrong address.