### PR TITLE
Fix abstract coder filter and map types

### DIFF
--- a/lib.esm/abi/coders/abstract-coder.d.ts
+++ b/lib.esm/abi/coders/abstract-coder.d.ts
@@ -38,11 +38,11 @@ export declare class Result extends Array<any> {
     /**
      *  @_ignore
      */
-    filter(callback: (el: any, index: number, array: Result) => boolean, thisArg?: any): Result;
+    filter<This = undefined>(predicate: (this: This, value: any, index: number, array: this) => boolean, thisArg?: This): any[];
     /**
      *  @_ignore
      */
-    map<T extends any = any>(callback: (el: any, index: number, array: Result) => T, thisArg?: any): Array<T>;
+    map<U, This = undefined>(callbackfn: (this: This, value: any, index: number, array: this) => U, thisArg?: This): Cast<{ [K in keyof this]: U }, U[]>;
     /**
      *  Returns the value for %%name%%.
      *


### PR DESCRIPTION
when running ethers with following libs & versions:
"better-typescript-lib": "2.6.0"
"typescript": "5.3.3"

I get following errors:
```ts
node_modules/ethers/lib.esm/abi/coders/abstract-coder.d.ts:41:5 - error TS2416: Property 'filter' in type 'Result' is not assignable to the same property in base type 'any[]'.
  Type '(callback: (el: any, index: number, array: Result) => boolean, thisArg?: any) => Result' is not assignable to type '{ <S extends any, This = undefined>(predicate: (this: This, value: any, index: number, array: this) => value is S, thisArg?: This | undefined): S[]; <This = undefined>(predicate: (this: This, value: any, index: number, array: this) => boolean, thisArg?: This | undefined): any[]; }'.
    Types of parameters 'callback' and 'predicate' are incompatible.
      Type '(this: any, value: any, index: number, array: this) => value is any' is not assignable to type '(el: any, index: number, array: Result) => boolean'.
        Types of parameters 'array' and 'array' are incompatible.
          Type 'Result' is not assignable to type 'this'.
            'Result' is assignable to the constraint of type 'this', but 'this' could be instantiated with a different subtype of constraint 'Result'.

41     filter(callback: (el: any, index: number, array: Result) => boolean, thisArg?: any): Result;
       ~~~~~~

node_modules/ethers/lib.esm/abi/coders/abstract-coder.d.ts:45:5 - error TS2416: Property 'map' in type 'Result' is not assignable to the same property in base type 'any[]'.
  Type '<T extends unknown = any>(callback: (el: any, index: number, array: Result) => T, thisArg?: any) => T[]' is not assignable to type '<U, This = undefined>(callbackfn: (this: This, value: any, index: number, array: this) => U, thisArg?: This | undefined) => Cast<{ [K in keyof this]: U; }, U[]>'.
    Types of parameters 'callback' and 'callbackfn' are incompatible.
      Types of parameters 'array' and 'array' are incompatible.
        Type 'Result' is not assignable to type 'this'.
          'Result' is assignable to the constraint of type 'this', but 'this' could be instantiated with a different subtype of constraint 'Result'.

45     map<T extends any = any>(callback: (el: any, index: number, array: Result) => T, thisArg?: any): Array<T>;
       ~~~
```

This pr fixes this typing issue