### PR TITLE
signTypedData: Can specify domain separator, not only domain object.

### DIFF
--- a/src.ts/wallet/base-wallet.ts
+++ b/src.ts/wallet/base-wallet.ts
@@ -3,7 +3,7 @@ import { hashMessage, TypedDataEncoder } from "../hash/index.js";
 import { AbstractSigner } from "../providers/index.js";
 import { computeAddress, Transaction } from "../transaction/index.js";
 import {
-    defineProperties, resolveProperties, assert, assertArgument
+    defineProperties, resolveProperties, assert, assertArgument, BytesLike
 } from "../utils/index.js";
 
 import type { SigningKey } from "../crypto/index.js";
@@ -105,7 +105,10 @@ export class BaseWallet extends AbstractSigner {
         return this.signingKey.sign(hashMessage(message)).serialized;
     }
 
-    async signTypedData(domain: TypedDataDomain, types: Record<string, Array<TypedDataField>>, value: Record<string, any>): Promise<string> {
+    /**
+     *  DOMAIN_SEPARATOR can be passed into %%domain%% directly.
+     */ 
+    async signTypedData(domain: TypedDataDomain | BytesLike, types: Record<string, Array<TypedDataField>>, value: Record<string, any>): Promise<string> {
 
         // Populate any ENS names
         const populated = await TypedDataEncoder.resolveNames(domain, types, value, async (name: string) => {


### PR DESCRIPTION
Sometimes, domain separator is constructed not according to EIP712 and we need a way to pass already computed value of domain_separator. (e.g., token USDC.e 0x2791bca1f2de4661ed88a30c99a7a9449aa84174 on Polygon)