### PR TITLE
Fix blockTag not being included on estimateGas calls

### DIFF
--- a/src.ts/providers/abstract-provider.ts
+++ b/src.ts/providers/abstract-provider.ts
@@ -363,7 +363,7 @@ export type PerformActionRequest = {
     method: "chainId"
 } | {
     method: "estimateGas",
-    transaction: PerformActionTransaction
+    transaction: PerformActionTransaction, blockTag: BlockTag
 } | {
     method: "getBalance",
     address: string, blockTag: BlockTag
@@ -954,10 +954,13 @@ export class AbstractProvider implements Provider {
 
 
     async estimateGas(_tx: TransactionRequest): Promise<bigint> {
-        let tx = this._getTransactionRequest(_tx);
+        let { tx, blockTag } = await resolveProperties({
+            tx: this._getTransactionRequest(_tx),
+            blockTag: this._getBlockTag(_tx.blockTag)
+        });
         if (isPromise(tx)) { tx = await tx; }
         return getBigInt(await this.#perform({
-            method: "estimateGas", transaction: tx
+            method: "estimateGas", transaction: tx, blockTag: blockTag
         }), "%response");
     }
 

--- a/src.ts/providers/provider-jsonrpc.ts
+++ b/src.ts/providers/provider-jsonrpc.ts
@@ -935,7 +935,7 @@ export abstract class JsonRpcApiProvider extends AbstractProvider {
             case "estimateGas": {
                 return {
                     method: "eth_estimateGas",
-                    args: [ this.getRpcTransaction(req.transaction) ]
+                    args: [ this.getRpcTransaction(req.transaction), req.blockTag ]
                 };
             }
 


### PR DESCRIPTION
Currently, the `blockTag` option for `estimateGas` is in the documentation and part of the Ethereum RPC spec, but it doesn't currently work in ethers. The option is defined on the input type `TransactionRequest`, but it's silently ignored in the processing code.

This fixes (or adds) this feature to enable blockTags on estimateGas. It uses it in the same manner and functions that `call` and other commands do, so it accepts the usual options (like `pending`, `latest`, a specific block numbers, etc.).

I think this covers the relevant code sections from my searching, but let me know if there's other fixes needed. 