### PR TITLE
Fixed setTimeout in node fetch driver

### DIFF
--- a/src.ts/utils/geturl.ts
+++ b/src.ts/utils/geturl.ts
@@ -37,7 +37,9 @@ export function createGetUrl(options?: Record<string, any>): FetchGetUrlFunc {
 
         const request = ((protocol === "http") ? http: https).request(req.url, reqOptions);
 
-        request.setTimeout(req.timeout);
+        request.setTimeout(req.timeout, () => {
+            request.destroy(new Error("request timeout"));
+        });
 
         const body = req.body;
         if (body) { request.write(Buffer.from(body)); }


### PR DESCRIPTION
I noticed that sometimes my indexer just freezes , and after couple days of debugging i found that the problem was with timouts in Ethers, it's just ignored. 