### PR TITLE
Fix: Missing error event

### DIFF
--- a/src.ts/providers/provider-jsonrpc.ts
+++ b/src.ts/providers/provider-jsonrpc.ts
@@ -560,7 +560,9 @@ export abstract class JsonRpcApiProvider extends AbstractProvider {
 
                             // The response is an error
                             if ("error" in resp) {
-                                reject(this.getRpcError(payload, resp));
+                                const error = this.getRpcError(payload, resp);
+                                this.emit("error", error);
+                                reject(error);
                                 continue;
                             }
 


### PR DESCRIPTION
For some error responses like the ones described in #4104 the error wasn't broadcasted to the event listeners.