### PR TITLE
Added fragment for Deferred Topic Filter

### DIFF
--- a/src.ts/contract/contract.ts
+++ b/src.ts/contract/contract.ts
@@ -500,7 +500,8 @@ async function getSubInfo(contract: BaseContract, event: ContractEventName): Pro
     } else if (isDeferred(event)) {
         // Deferred Topic Filter; e.g. `contract.filter.Transfer(from)`
         topics = await event.getTopicFilter();
-
+        if(event.fragment)fragment = event.fragment
+        
     } else if ("fragment" in event) {
         // ContractEvent; e.g. `contract.filter.Transfer`
         fragment = event.fragment;


### PR DESCRIPTION
Subscribing with contract.filter.EventName(someValue...) returns the entire log object instead of returning the Event arguments to the listener. Other checks bellow check if fragment is present in the event but since it's an 'else if' it never triggers.