### PR TITLE
Fix: Make Interface.from() Full Clone

### DIFF
--- a/src.ts/abi/interface.ts
+++ b/src.ts/abi/interface.ts
@@ -1257,7 +1257,12 @@ export class Interface {
 
         // Maybe an interface from an older version, or from a symlinked copy
         if (typeof((<any>value).format) === "function") {
-            return new Interface((<any>value).format("json"));
+            // format("json") implies minimal, which drops output args
+            // the argument can simply be removed because:
+            // v5: format() defaults to full: https://github.com/ethers-io/ethers.js/blob/555f16ce7bc6f5fcb40f4c88037f3e4e4182c36c/packages/abi/src.ts/interface.ts#L159
+            // v6: format() => !minimal => full
+            // alternatively, we could probe for formatJson() but that doesn't exist in v5
+            return new Interface((<any>value).format());
         }
 
         // Array of fragments


### PR DESCRIPTION
`Interface.format("json")` in v6 implies "minimal" which causes `Interface.from()` to drop a lot of meta information.

Instead, arg-less `format()` should be called.

In v5, it's safe to call arg-less `format()`, as the default is `Full`
https://github.com/ethers-io/ethers.js/blob/555f16ce7bc6f5fcb40f4c88037f3e4e4182c36c/

```js
// Maybe an interface from an older version, or from a symlinked copy
if (typeof((<any>value).format) === "function") {
    // OLD:
    //return new Interface((<any>value).format("json"));

    // NEW:
    return new Interface((<any>value).format());
}
```

Alternatively, this could do an additional check for `formatJson()` from v6.