### PR TITLE
WebSocketLike : Add onclose method

### DIFF
--- a/src.ts/providers/provider-websocket.ts
+++ b/src.ts/providers/provider-websocket.ts
@@ -14,6 +14,7 @@ export interface WebSocketLike {
     onopen: null | ((...args: Array<any>) => any);
     onmessage: null | ((...args: Array<any>) => any);
     onerror: null | ((...args: Array<any>) => any);
+    onclose: null | ((...args: Array<any>) => any);
 
     readyState: number;
 


### PR DESCRIPTION
Hi everyone,

I've tried to add a `onclose` listener on my websocket but the interface didn't allow me.

After verifying that underlying websocket class own a onclose method I decide to make this little PR to extends the interface.

Have a nice day.