### PR TITLE
fix: use non-capturing group in getBytes regexp

### DIFF
--- a/src.ts/utils/data.ts
+++ b/src.ts/utils/data.ts
@@ -31,7 +31,7 @@ function _getBytes(value: BytesLike, name?: string, copy?: boolean): Uint8Array 
         return value;
     }
 
-    if (typeof(value) === "string" && value.match(/^0x([0-9a-f][0-9a-f])*$/i)) {
+    if (typeof(value) === "string" && value.match(/^0x(?:[0-9a-f][0-9a-f])*$/i)) {
         const result = new Uint8Array((value.length - 2) / 2);
         let offset = 2;
         for (let i = 0; i < result.length; i++) {


### PR DESCRIPTION
While doing huge read request I encountered following error in my code:

```
RangeError: Maximum call stack size exceeded 
    at String.match (<anonymous>)
    at _getBytes (/app/node_modules/ethers/src.ts/utils/data.ts:34:45)
    at getBytes (/app/node_modules/ethers/src.ts/utils/data.ts:55:12)
    at hexlify (/app/node_modules/ethers/src.ts/utils/data.ts:102:19)
    at JsonRpcProvider.#call (/app/node_modules/ethers/src.ts/providers/abstract-provider.ts:974:28)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

With some insight from this post [here](https://stackoverflow.com/a/71753099) I changed regexp to use non-capturing group, and that fixed my app.
