### PR TITLE
Fix typo ('executre' -> 'execute')

### DIFF
--- a/lib.commonjs/providers/provider.d.ts
+++ b/lib.commonjs/providers/provider.d.ts
@@ -1133,7 +1133,7 @@ export interface Provider extends ContractRunner, EventEmitterable<ProviderEvent
      */
     getStorage(address: AddressLike, position: BigNumberish, blockTag?: BlockTag): Promise<string>;
     /**
-     *  Estimates the amount of gas required to executre %%tx%%.
+     *  Estimates the amount of gas required to execute %%tx%%.
      */
     estimateGas(tx: TransactionRequest): Promise<bigint>;
     /**

--- a/lib.esm/providers/provider.d.ts
+++ b/lib.esm/providers/provider.d.ts
@@ -1133,7 +1133,7 @@ export interface Provider extends ContractRunner, EventEmitterable<ProviderEvent
      */
     getStorage(address: AddressLike, position: BigNumberish, blockTag?: BlockTag): Promise<string>;
     /**
-     *  Estimates the amount of gas required to executre %%tx%%.
+     *  Estimates the amount of gas required to execute %%tx%%.
      */
     estimateGas(tx: TransactionRequest): Promise<bigint>;
     /**

--- a/src.ts/providers/provider.ts
+++ b/src.ts/providers/provider.ts
@@ -2014,7 +2014,7 @@ export interface Provider extends ContractRunner, EventEmitterable<ProviderEvent
     // Execution
 
     /**
-     *  Estimates the amount of gas required to executre %%tx%%.
+     *  Estimates the amount of gas required to execute %%tx%%.
      */
     estimateGas(tx: TransactionRequest): Promise<bigint>;
 


### PR DESCRIPTION
Fixed a simple typo