### PR TITLE
Add more chains to ChainstackProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ in [TypeScript](https://www.typescriptlang.org).
 - Import and export **JSON wallets** (Geth, Parity and crowdsale)
 - Import and export BIP 39 **mnemonic phrases** (12 word backup phrases) and **HD Wallets** (English as well as Czech, French, Italian, Japanese, Korean, Simplified Chinese, Spanish, Traditional Chinese)
 - Meta-classes create JavaScript objects from any contract ABI, including **ABIv2** and **Human-Readable ABI**
-- Connect to Ethereum nodes over [JSON-RPC](https://github.com/ethereum/wiki/wiki/JSON-RPC), [INFURA](https://infura.io), [Etherscan](https://etherscan.io), [Alchemy](https://alchemyapi.io), [Ankr](https://ankr.com) or [MetaMask](https://metamask.io)
+- Connect to Ethereum nodes over [JSON-RPC](https://github.com/ethereum/wiki/wiki/JSON-RPC), [INFURA](https://infura.io), [Etherscan](https://etherscan.io), [Alchemy](https://alchemyapi.io), [Ankr](https://ankr.com), [Chainstack](https://chainstack.com),  or [MetaMask](https://metamask.io)
 - **ENS names** are first-class citizens; they can be used anywhere an Ethereum addresses can be used
 - **Small** (~144kb compressed; 460kb uncompressed)
 - **Tree-shaking** focused; include only what you need during bundling
@@ -117,6 +117,7 @@ A special thanks to these services for providing community resources:
 - [Etherscan](https://etherscan.io/)
 - [INFURA](https://infura.io/)
 - [Alchemy](https://dashboard.alchemyapi.io/signup?referral=55a35117-028e-4b7c-9e47-e275ad0acc6d)
+- [Chainstack](https://chainstack.com/)
 
 
 Extension Packages

--- a/src.ts/_tests/create-provider.ts
+++ b/src.ts/_tests/create-provider.ts
@@ -51,7 +51,7 @@ const ProviderCreators: Array<ProviderCreator> = [
     */
     {
         name: "ChainstackProvider",
-        networks: [ "default", "mainnet", "arbitrum", "bnb", "matic" ],
+        networks: [ "default", "mainnet", "arbitrum", "bnb", "matic", "base", "optimism", "sepolia", "holesky", "arbitrum-sepolia", "bnbt", "matic-amoy", "base-sepolia", "optimism-sepolia" ],
         create: function(network: string) {
             return new ChainstackProvider(network);
         }

--- a/src.ts/providers/provider-chainstack.ts
+++ b/src.ts/providers/provider-chainstack.ts
@@ -8,6 +8,15 @@
  *  - Arbitrum (``arbitrum``)
  *  - BNB Smart Chain Mainnet (``bnb``)
  *  - Polygon (``matic``)
+ *  - Base (``base``)
+ *  - Optimism (``optimism``)
+ *  - Sepolia Testnet (``sepolia``)
+ *  - Holeski Testnet (``holeski``)
+ *  - Arbitrum Sepolia Testnet (``arbitrum-sepolia``)
+ *  - BNB Smart Chain Testnet (``bnbt``)
+ *  - Polygon Amoy Testnet (``matic-amoy``) 
+ *  - Base Sepolia Testnet (``base-sepolia``)
+ *  - Optimism Sepolia Testnet (``optimism-sepolia``)  
  *
  *  @_subsection: api/providers/thirdparty:Chainstack  [providers-chainstack]
  */
@@ -27,9 +36,18 @@ import type { Networkish } from "./network.js";
 function getApiKey(name: string): string {
     switch (name) {
         case "mainnet": return "39f1d67cedf8b7831010a665328c9197";
-        case "arbitrum": return "0550c209db33c3abf4cc927e1e18cea1"
+        case "arbitrum": return "0550c209db33c3abf4cc927e1e18cea1";
         case "bnb": return "98b5a77e531614387366f6fc5da097f8";
         case "matic": return "cd9d4d70377471aa7c142ec4a4205249";
+        case "base": return "f7e96b2c9129bcd7a571125c3e2a9672";
+        case "optimism": return "c33ecbe4ae1be1311452ed472d8ad46a";
+        case "sepolia": return "2376020706e35a4756462faf9a71b208";
+        case "holesky": return "631810e152d4046bb660e08bcec92794";
+        case "arbitrum-sepolia`": return "3aea296a4ff0b638245e2b40dda113fb";
+        case "bnbt": return "5643c7df594dcdfb01304de11331f795";
+        case "matic-amoy": return "241d9f34fee2c4c1c86efa9821534067";
+        case "base-sepolia": return "a23461eb9b2026654d5507fe6a92085a";
+        case "optimism-sepolia": return "4cd31436760a1d9d0912bceeeced641b";
     }
 
     assertArgument(false, "unsupported network", "network", name);
@@ -45,6 +63,24 @@ function getHost(name: string): string {
             return "bsc-mainnet.core.chainstack.com";
         case "matic":
             return "polygon-mainnet.core.chainstack.com";
+        case "base":
+            return "base-mainnet.core.chainstack.com";
+        case "optimism":
+            return "optimism-mainnet.core.chainstack.com";
+        case "sepolia":
+            return "ethereum-sepolia.core.chainstack.com";
+        case "holesky":
+            return "ethereum-holesky.core.chainstack.com";
+        case "arbitrum-sepolia":
+            return "arbitrum-sepolia.core.chainstack.com";
+        case "bnbt":
+            return "bsc-testnet.core.chainstack.com";
+        case "matic-amoy":
+            return "polygon-amoy.core.chainstack.com";
+        case "base-sepolia":
+            return "base-sepolia.core.chainstack.com";
+        case "optimism-sepolia":
+            return "optimism-sepolia.core.chainstack.com";
     }
 
     assertArgument(false, "unsupported network", "network", name);


### PR DESCRIPTION
Add more chains to `ChainstackProvider`:
 - Base
 - Optimism
 - Sepolia Testnet
 - Holeski Testnet
 - Arbitrum Sepolia Testnet
 - BNB Smart Chain Testnet
 - Polygon Amoy Testnet
 - Base Sepolia Testnet
 - Optimism Sepolia Testnet

Added Chainstack link in the providers' section of the README