### PR TITLE
Fix for prepended empty bytes on KeystoreJson decrypt

### DIFF
--- a/src.ts/wallet/json-keystore.ts
+++ b/src.ts/wallet/json-keystore.ts
@@ -91,7 +91,11 @@ function getAccount(data: any, _key: string): KeystoreAccount {
     assertArgument(computedMAC === spelunk<string>(data, "crypto.mac:string!").toLowerCase(),
         "incorrect password", "password", "[ REDACTED ]");
 
-    const privateKey = decrypt(data, key.slice(0, 16), ciphertext);
+    const decryptedPrivateKey = decrypt(data, key.slice(0, 16), ciphertext);
+
+    const privateKey = decryptedPrivateKey.startsWith("0x00")
+      ? decryptedPrivateKey.replace("0x00", "0x")
+      : decryptedPrivateKey;
 
     const address = computeAddress(privateKey);
     if (data.address) {


### PR DESCRIPTION
In certain scenarios, decrypting a KeystoreJson can result in `00` being prepended to a private key in the `getAccount` function.

### Here is an example with a random key

Json:
```
{"crypto":{"cipher":"aes-128-ctr","cipherparams":{"iv":"2e9dc1c889a994f29f84501a88ee28df"},"ciphertext":"9b46c206388bc115b8ac811d288c68f7ae04a7501d5ae5a67dfb230525bbfb61","kdf":"scrypt","kdfparams":{"dklen":32,"n":512,"r":8,"p":1,"salt":"4e87b121893d3082cd70212cbb4c0114e0d858e7d91092c8af3f6d599a6d2072"},"mac":"46ec1e91ec891c0fd018ec4d098036e7f41d5871278631c590349f2c094161dd"},"id":"f04398b6-d60b-4d6b-88b2-6fb9aaa69487","version":3}
```

Password: 
```
1edw8fROhOix-1QcaXQxXeoA2aCFvpHPeZxESqx-hKLHIxzVBhk8bLb8DMALuclUlbhq-arWJdMVuLM3l3uMsA==
```

The resulting private key should be: 
```
0x54fc8d2c19216406f12e587253d4a52c20c6af9e1d98248381fb6133d732798f
```

But internally, the decrypt function returns: 
```
0x0054fc8d2c19216406f12e587253d4a52c20c6af9e1d98248381fb6133d732798f
``` 

### Additional Context

This KeystoreJson and private key was generated using [web3dart](https://github.com/xclud/web3dart)