### PR TITLE
Do not increment NonceManager delta if transaction send fails

### DIFF
--- a/src.ts/providers/signer-noncemanager.ts
+++ b/src.ts/providers/signer-noncemanager.ts
@@ -73,15 +73,18 @@ export class NonceManager extends AbstractSigner {
     }
 
     async sendTransaction(tx: TransactionRequest): Promise<TransactionResponse> {
-        const noncePromise = this.getNonce("pending");
-        this.increment();
+        try {
+            const noncePromise = this.getNonce("pending");
+            this.increment();
 
-        tx = await this.signer.populateTransaction(tx);
-        tx.nonce = await noncePromise;
+            tx = await this.signer.populateTransaction(tx);
+            tx.nonce = await noncePromise;
 
-        // @TODO: Maybe handle interesting/recoverable errors?
-        // Like don't increment if the tx was certainly not sent
-        return await this.signer.sendTransaction(tx);
+            return await this.signer.sendTransaction(tx);
+        } catch (err) {
+            this.#delta--;
+            throw err;
+        }
     }
 
     signTransaction(tx: TransactionRequest): Promise<string> {


### PR DESCRIPTION
If the sendTransaction call fails for any reason like your node/provider going down, subsequent calls to sendTransaction will fail until the user manually calls reset in their catch clause wrapping sendTransaction which I would assume not many people do.

Automatically handling this would save people lots of headache and outages.
