### PR TITLE
feat: add ethers v6 codemods

### DIFF
--- a/docs.wrm/migrating.wrm
+++ b/docs.wrm/migrating.wrm
@@ -82,9 +82,10 @@ _code: simple comparison on large numbers  @lang<script>
   // Using BigInt in v6
   isEqual = (value1 == value2)
 
-**Note**: Codemod transforms BigNumber to BigInt and also refactors addition and equality with:
-```bash
-npx codemod@latest Ethers/6/Big-Numbers
+_note: Codemod transforms BigNumber to BigInt and also refactors addition and equality with:
+
+_code:
+  npx codemod@latest Ethers/6/Big-Numbers
 
 
 _subsection: Contracts @<migrate-contracts>
@@ -140,6 +141,11 @@ _code: contracts in v6  @lang<script>
   // allows providing typing information to the Contract:
   contract.foo(Typed.address(addr))
 
+_note: Codemod transforms the ambiguous function to TypedAPI function:
+
+_code:
+  npx codemod@latest Ethers/6/Contracts/Ambiguous-Methods
+
 _heading: Other Method Operations
 
 In v5, contracts contained a series of method buckets, which
@@ -188,6 +194,11 @@ _code: other operations in v6  @lang<script>
   // Populate a transaction
   contract.foo.populateTransaction(addr)
 
+_note: Codemod refactors all the functions mentioned above:
+
+_code:
+  npx codemod@latest Ethers/6/Contracts/Other-Method-Operations
+
 
 _subsection: Importing  @<migrate-importing>
 
@@ -219,6 +230,11 @@ _code: importing in v6  @lang<script>
 
   // The pkg.exports provides granular access
   import { InfuraProvider } from "ethers/providers"
+
+_note: Codemod updates import statements to new structure:
+
+_code:
+  npx codemod@latest Ethers/6/Importing
 
 
 _subsection: Providers  @<migrate-providers>
@@ -288,6 +304,11 @@ _code: Getting legacy gas price  @lang<script>
   (await provider.getFeeData()).gasPrice
 
 
+_note: Codemod updates provider class, transaction broadcasting method, static network providers, and fee data-retrieval to align with new structure:
+
+_code:
+  npx codemod@latest Ethers/6/Providers
+
 _subsection: Signatures  @<migrate-signatures>
 
 The Signature is now a class which facilitates all the parsing
@@ -301,6 +322,11 @@ _code: signature manipulation
   // v6
   splitSig = ethers.Signature.from(sigBytes)
   sigBytes = ethers.Signature.from(splitSig).serialized
+
+_note: Codemod replaces [[splitSignature]] and [[joinSignature]] with [[ethers.Signature]] class for parsing and serializing singatures:
+
+_code:
+  npx codemod@latest Ethers/6/Signatures
 
 
 _subsection: Transactions  @<migrate-transactions>
@@ -321,6 +347,11 @@ _code: parsing transactions  @lang<script>
 
   // v6 (the tx can optionally include the signature)
   txBytes = Transaction.from(tx).serialized
+
+_note: Codemod replaces [[parseTransaction]] and [[serializeTransaction]] with new [[Transaction]] class for parsing and serializing singatures:
+
+_code:
+  npx codemod@latest Ethers/6/Transactions
 
 
 _subsection: Utilities  @<migrate-utils>
@@ -450,6 +481,11 @@ _code: commify  @lang<script>
   }
 
   commify("1234.5");
+
+_note: Codemod refactors various utility methods mentioned above, constants, data manipualtion functions, and transaction handling:
+
+_code:
+  npx codemod@latest Ethers/6/Utilities
 
 _subsection: Removed Classes and functions  @<migrate-missing>
 


### PR DESCRIPTION
This PR adds instructions on using the [ethers-v6-codemods](https://codemod.com/registry/Ethers-6-migration-recipe).

This codemod automates the process of migrating to v6 of ethers.js

You can test/run the codemod using:

```bash
npx codemod@latest Ethers/6/Migration-Recipe
```

This allows Ethers.js v5 users to easily automate the changes mentioned in the migration guide to Ethers v6 with a one-line command.