### PR TITLE
fixed provider-jsonrpc.ts strict compile fixes and error handling

### DIFF
--- a/src.ts/providers/provider-jsonrpc.ts
+++ b/src.ts/providers/provider-jsonrpc.ts
@@ -382,14 +382,15 @@ export class JsonRpcSigner extends AbstractSigner<JsonRpcApiProvider> {
                     // If the network changed: calling again will also fail
                     // If unsupported: likely destroyed
                     if (isError(error, "CANCELLED") || isError(error, "BAD_DATA") ||
-                        isError(error, "NETWORK_ERROR" || isError(error, "UNSUPPORTED_OPERATION"))) {
-
+                        isError(error, "NETWORK_ERROR") || isError(error, "UNSUPPORTED_OPERATION")) {
+                    
                         if (error.info == null) { error.info = { }; }
                         error.info.sendTransactionHash = hash;
-
+                    
                         reject(error);
                         return;
                     }
+
 
                     // Stop-gap for misbehaving backends; see #4513
                     if (isError(error, "INVALID_ARGUMENT")) {


### PR DESCRIPTION
The original condition used "NETWORK_ERROR" || isError(error, "UNSUPPORTED_OPERATION") which is always truthy due to the way the logical OR operator (||) is evaluated. This caused the if statement to not function as intended, potentially resulting in unexpected rejections during transaction handling.