### PR TITLE
Logic Error in provider-jsonrpc.ts line 385

### DIFF
--- a/src.ts/providers/provider-jsonrpc.ts
+++ b/src.ts/providers/provider-jsonrpc.ts
@@ -382,7 +382,7 @@ export class JsonRpcSigner extends AbstractSigner<JsonRpcApiProvider> {
                     // If the network changed: calling again will also fail
                     // If unsupported: likely destroyed
                     if (isError(error, "CANCELLED") || isError(error, "BAD_DATA") ||
-                        isError(error, "NETWORK_ERROR" || isError(error, "UNSUPPORTED_OPERATION"))) {
+                        isError(error, "NETWORK_ERROR") || isError(error, "UNSUPPORTED_OPERATION")) {
 
                         if (error.info == null) { error.info = { }; }
                         error.info.sendTransactionHash = hash;


### PR DESCRIPTION
Logical error in src.ts/providers/provider-jsonrpc.ts line 385:

Logical OR Operator (||) Grouping:

The original code had a misplaced parenthesis: 

isError(error, "NETWORK_ERROR" || isError(error, "UNSUPPORTED_OPERATION")).

This caused "NETWORK_ERROR" || isError(error, "UNSUPPORTED_OPERATION") to always evaluate to "NETWORK_ERROR" (a truthy value), making the entire condition always true.

Corrected Grouping:

isError(error, "NETWORK_ERROR") || isError(error, "UNSUPPORTED_OPERATION")

Each isError function call should be individually evaluated and then combined using the || operator.
This ensures that the condition checks if the error matches any of the specified error codes correctly.