### PR TITLE
feature: export formatTransactionResponse under providers

### DIFF
--- a/src.ts/providers/index.ts
+++ b/src.ts/providers/index.ts
@@ -78,6 +78,8 @@ export {
     SocketEventSubscriber
 } from "./provider-socket.js";
 
+export { formatTransactionResponse } from "./format.js";
+
 export type {
     AbstractProviderOptions, Subscription, Subscriber,
     AbstractProviderPlugin,


### PR DESCRIPTION
It is necessary and reasonable to export formatTransactionResponse in the Provider module #4849 