### PR TITLE
fix: failed find tx

### DIFF
--- a/src.ts/providers/provider.ts
+++ b/src.ts/providers/provider.ts
@@ -711,7 +711,7 @@ export class Block implements BlockParams, Iterable<string> {
                     tx = v;
                     break;
                 } else {
-                    if (v.hash === hash) { continue; }
+                    if (v.hash !== hash) { continue; }
                     tx = v;
                     break;
                 }


### PR DESCRIPTION
Fixed the abnormal logic of finding tx. #4867 

The current tx should be skipped when there is no match instead of skipping when there is a match.
