### PR TITLE
fix: remove safeguard in from field for signer

### DIFF
--- a/src.ts/providers/abstract-signer.ts
+++ b/src.ts/providers/abstract-signer.ts
@@ -33,17 +33,7 @@ async function populate(signer: AbstractSigner, tx: TransactionRequest): Promise
 
     if (pop.to != null) { pop.to = resolveAddress(pop.to, signer); }
 
-    if (pop.from != null) {
-        const from = pop.from;
-        pop.from = Promise.all([
-            signer.getAddress(),
-            resolveAddress(from, signer)
-        ]).then(([ address, from ]) => {
-            assertArgument(address.toLowerCase() === from.toLowerCase(),
-                "transaction from mismatch", "tx.from", from);
-            return address;
-        });
-    } else {
+    if (pop.from == null) {
         pop.from = signer.getAddress();
     }
 


### PR DESCRIPTION
Hi,

With account abstraction or smart account, it is common to be able to sign transaction with a different private key as the "from field"

One example is a multisig smart account which authorize multiple signers to sign on the behalf of one account. 

I think the safeguard should be removed as it is not compatible with most of the "smart account" use case.