### PR TITLE
Prevent `checkType` errors due to custom Object prototypes in `ParamType`

### DIFF
--- a/src.ts/utils/properties.ts
+++ b/src.ts/utils/properties.ts
@@ -50,6 +50,8 @@ export function defineProperties<T>(
  types?: { [ K in keyof T ]?: string }): void {
 
     for (let key in values) {
+        if (!Object.prototype.hasOwnProperty.call(values, key)) continue;
+
         let value = values[key];
 
         const type = (types ? types[key]: null);


### PR DESCRIPTION
Related to https://github.com/ethers-io/ethers.js/issues/4896