### PR TITLE
Fix typos

### DIFF
--- a/lib.commonjs/utils/fixednumber.d.ts
+++ b/lib.commonjs/utils/fixednumber.d.ts
@@ -50,7 +50,7 @@ export type FixedFormat = number | string | {
  *  If operations are performed that cause a value to become too small
  *  (close to zero), the value loses precison and is said to //underflow//.
  *
- *  For example, an value with 1 decimal place may store a number as small
+ *  For example, a value with 1 decimal place may store a number as small
  *  as ``0.1``, but the value of ``0.1 / 2`` is ``0.05``, which cannot fit
  *  into 1 decimal place, so underflow occurs which means precision is lost
  *  and the value becomes ``0``.

--- a/lib.esm/providers/formatting.d.ts
+++ b/lib.esm/providers/formatting.d.ts
@@ -40,7 +40,7 @@ export interface BlockParams {
     nonce: string;
     /**
      *  For proof-of-work networks, the difficulty target is used to
-     *  adjust the difficulty in mining to ensure a expected block rate.
+     *  adjust the difficulty in mining to ensure an expected block rate.
      */
     difficulty: bigint;
     /**

--- a/lib.esm/utils/fixednumber.d.ts
+++ b/lib.esm/utils/fixednumber.d.ts
@@ -50,7 +50,7 @@ export type FixedFormat = number | string | {
  *  If operations are performed that cause a value to become too small
  *  (close to zero), the value loses precison and is said to //underflow//.
  *
- *  For example, an value with 1 decimal place may store a number as small
+ *  For example, a value with 1 decimal place may store a number as small
  *  as ``0.1``, but the value of ``0.1 / 2`` is ``0.05``, which cannot fit
  *  into 1 decimal place, so underflow occurs which means precision is lost
  *  and the value becomes ``0``.

--- a/src.ts/providers/formatting.ts
+++ b/src.ts/providers/formatting.ts
@@ -52,7 +52,7 @@ export interface BlockParams {
 
     /**
      *  For proof-of-work networks, the difficulty target is used to
-     *  adjust the difficulty in mining to ensure a expected block rate.
+     *  adjust the difficulty in mining to ensure an expected block rate.
      */
     difficulty: bigint;
 


### PR DESCRIPTION
This pull request corrects grammatical errors in type definition files (`.d.ts`) and a source file (`formatting.ts`) to improve clarity and accuracy in documentation and comments.

### Summary of Changes:
1. **Grammatical Fixes**:
   - Replaced "an value" with "a value" in `fixednumber.d.ts`.
   - Updated "a expected" to "an expected" in `formatting.d.ts` and `formatting.ts`.

2. **Files Modified**:
   - `lib.commonjs/utils/fixednumber.d.ts`
   - `lib.esm/providers/formatting.d.ts`
   - `lib.esm/utils/fixednumber.d.ts`
   - `src.ts/providers/formatting.ts`
