### PR TITLE
Remove useless polygon gas station

### DIFF
--- a/lib.commonjs/providers/default-provider.d.ts
+++ b/lib.commonjs/providers/default-provider.d.ts
@@ -27,7 +27,6 @@ import { WebSocketLike } from "./provider-websocket.js";
  *  - ``"chainstack"``
  *  - ``"etherscan"``
  *  - ``"infura"``
- *  - ``"publicPolygon"``
  *  - ``"quicknode"``
  *
  *  @example:
@@ -46,4 +45,3 @@ import { WebSocketLike } from "./provider-websocket.js";
  *    });
  */
 export declare function getDefaultProvider(network?: string | Networkish | WebSocketLike, options?: any): AbstractProvider;
-//# sourceMappingURL=default-provider.d.ts.map

--- a/lib.commonjs/providers/default-provider.js
+++ b/lib.commonjs/providers/default-provider.js
@@ -45,7 +45,6 @@ const Testnets = "goerli kovan sepolia classicKotti optimism-goerli arbitrum-goe
  *  - ``"chainstack"``
  *  - ``"etherscan"``
  *  - ``"infura"``
- *  - ``"publicPolygon"``
  *  - ``"quicknode"``
  *
  *  @example:
@@ -92,14 +91,6 @@ function getDefaultProvider(network, options) {
     }
     catch (error) { }
     const providers = [];
-    if (allowService("publicPolygon") && staticNetwork) {
-        if (staticNetwork.name === "matic") {
-            providers.push(new provider_jsonrpc_js_1.JsonRpcProvider("https:/\/polygon-rpc.com/", staticNetwork, { staticNetwork }));
-        }
-        else if (staticNetwork.name === "matic-amoy") {
-            providers.push(new provider_jsonrpc_js_1.JsonRpcProvider("https:/\/rpc-amoy.polygon.technology/", staticNetwork, { staticNetwork }));
-        }
-    }
     if (allowService("alchemy")) {
         try {
             providers.push(new provider_alchemy_js_1.AlchemyProvider(network, options.alchemy));

--- a/lib.commonjs/providers/provider-ankr.d.ts
+++ b/lib.commonjs/providers/provider-ankr.d.ts
@@ -16,8 +16,6 @@
  *  - Optimism (``optimism``)
  *  - Optimism Goerli Testnet (``optimism-goerli``)
  *  - Optimism Sepolia Testnet (``optimism-sepolia``)
- *  - Polygon (``matic``)
- *  - Polygon Mumbai Testnet (``matic-mumbai``)
  *
  *  @_subsection: api/providers/thirdparty:Ankr  [providers-ankr]
  */

--- a/lib.commonjs/providers/provider-chainstack.d.ts
+++ b/lib.commonjs/providers/provider-chainstack.d.ts
@@ -7,7 +7,6 @@
  *  - Ethereum Mainnet (``mainnet``)
  *  - Arbitrum (``arbitrum``)
  *  - BNB Smart Chain Mainnet (``bnb``)
- *  - Polygon (``matic``)
  *
  *  @_subsection: api/providers/thirdparty:Chainstack  [providers-chainstack]
  */

--- a/lib.commonjs/providers/provider-etherscan.d.ts
+++ b/lib.commonjs/providers/provider-etherscan.d.ts
@@ -17,9 +17,6 @@
  *  - BNB Smart Chain Testnet (``bnbt``)
  *  - Optimism (``optimism``)
  *  - Optimism Goerli Testnet (``optimism-goerli``)
- *  - Polygon (``matic``)
- *  - Polygon Mumbai Testnet (``matic-mumbai``)
- *  - Polygon Amoy Testnet (``matic-amoy``)
  *
  *  @_subsection api/providers/thirdparty:Etherscan  [providers-etherscan]
  */

--- a/src.ts/providers/network.ts
+++ b/src.ts/providers/network.ts
@@ -320,32 +320,6 @@ function parseUnits(_value: number | string, decimals: number): bigint {
     return BigInt(comps[0] + comps[1]);
 }
 
-// Used by Polygon to use a gas station for fee data
-function getGasStationPlugin(url: string) {
-    return new FetchUrlFeeDataNetworkPlugin(url, async (fetchFeeData, provider, request) => {
-
-        // Prevent Cloudflare from blocking our request in node.js
-        request.setHeader("User-Agent", "ethers");
-
-        let response;
-        try {
-            const [ _response, _feeData ] = await Promise.all([
-                request.send(), fetchFeeData()
-            ]);
-            response = _response;
-            const payload = response.bodyJson.standard;
-            const feeData = {
-                gasPrice: _feeData.gasPrice,
-                maxFeePerGas: parseUnits(payload.maxFee, 9),
-                maxPriorityFeePerGas: parseUnits(payload.maxPriorityFee, 9),
-            };
-            return feeData;
-        } catch (error: any) {
-            assert(false, `error encountered with polygon gas station (${ JSON.stringify(request.url) })`, "SERVER_ERROR", { request, response, error });
-        }
-    });
-}
-
 // See: https://chainlist.org
 let injected = false;
 function injectCommonNetworks(): void {
@@ -411,17 +385,11 @@ function injectCommonNetworks(): void {
     registerEth("linea-sepolia", 59141, { });
 
     registerEth("matic", 137, {
-        ensNetwork: 1,
-        plugins: [
-            getGasStationPlugin("https:/\/gasstation.polygon.technology/v2")
-        ]
+        ensNetwork: 1
     });
     registerEth("matic-amoy", 80002, { });
     registerEth("matic-mumbai", 80001, {
-        altNames: [ "maticMumbai", "maticmum" ],  // @TODO: Future remove these alts
-        plugins: [
-            getGasStationPlugin("https:/\/gasstation-testnet.polygon.technology/v2")
-        ]
+        altNames: [ "maticMumbai", "maticmum" ]
     });
 
     registerEth("optimism", 10, {

--- a/src.ts/providers/provider-etherscan.ts
+++ b/src.ts/providers/provider-etherscan.ts
@@ -17,9 +17,6 @@
  *  - BNB Smart Chain Testnet (``bnbt``)
  *  - Optimism (``optimism``)
  *  - Optimism Goerli Testnet (``optimism-goerli``)
- *  - Polygon (``matic``)
- *  - Polygon Mumbai Testnet (``matic-mumbai``)
- *  - Polygon Amoy Testnet (``matic-amoy``)
  *
  *  @_subsection api/providers/thirdparty:Etherscan  [providers-etherscan]
  */
@@ -181,12 +178,6 @@ export class EtherscanProvider extends AbstractProvider {
                 return "https:/\/api.bscscan.com";
             case "bnbt":
                 return "https:/\/api-testnet.bscscan.com";
-            case "matic":
-                return "https:/\/api.polygonscan.com";
-            case "matic-amoy":
-                return "https:/\/api-amoy.polygonscan.com";
-            case "matic-mumbai":
-                return "https:/\/api-testnet.polygonscan.com";
             case "optimism":
                 return "https:/\/api-optimistic.etherscan.io";
             case "optimism-goerli":


### PR DESCRIPTION
Related to #4909

Remove the duplicate Polygon gas station API references.

* Remove references to `polygon-rpc.com` and `rpc-amoy.polygon.technology` in `lib.commonjs/providers/default-provider.js`.
* Remove `publicPolygon` as a supported backend string in `lib.commonjs/providers/default-provider.d.ts`.
* Remove gas station plugin for Polygon networks in `src.ts/providers/network.ts`.
* Remove support for Polygon networks in `src.ts/providers/provider-etherscan.ts`, `lib.commonjs/providers/provider-etherscan.d.ts`, `lib.commonjs/providers/provider-ankr.d.ts`, and `lib.commonjs/providers/provider-chainstack.d.ts`.

