### PR TITLE
docs: fixed typo in transactionReceipt.gasPrice description (#4390)

### DIFF
--- a/lib.commonjs/providers/provider.d.ts
+++ b/lib.commonjs/providers/provider.d.ts
@@ -604,7 +604,7 @@ export declare class TransactionReceipt implements TransactionReceiptParams, Ite
      *  The actual gas price used during execution.
      *
      *  Due to the complexity of [[link-eip-1559]] this value can only
-     *  be caluclated after the transaction has been mined, snce the base
+     *  be calculated after the transaction has been mined, snce the base
      *  fee is protocol-enforced.
      */
     readonly gasPrice: bigint;

--- a/lib.esm/providers/provider.d.ts
+++ b/lib.esm/providers/provider.d.ts
@@ -604,7 +604,7 @@ export declare class TransactionReceipt implements TransactionReceiptParams, Ite
      *  The actual gas price used during execution.
      *
      *  Due to the complexity of [[link-eip-1559]] this value can only
-     *  be caluclated after the transaction has been mined, snce the base
+     *  be calculated after the transaction has been mined, snce the base
      *  fee is protocol-enforced.
      */
     readonly gasPrice: bigint;

--- a/src.ts/providers/provider.ts
+++ b/src.ts/providers/provider.ts
@@ -1019,7 +1019,7 @@ export class TransactionReceipt implements TransactionReceiptParams, Iterable<Lo
      *  The actual gas price used during execution.
      *
      *  Due to the complexity of [[link-eip-1559]] this value can only
-     *  be caluclated after the transaction has been mined, snce the base
+     *  be calculated after the transaction has been mined, snce the base
      *  fee is protocol-enforced.
      */
     readonly gasPrice!: bigint;


### PR DESCRIPTION
Replaced 'caluclated' with 'calculated' in the documentation for the transactionReceipt.gasPrice field. Resolves #4390.