### PR TITLE
Add optional hedged signatures. Update noble deps. Closes gh-4885.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,8 @@
       "license": "MIT",
       "dependencies": {
         "@adraffy/ens-normalize": "1.10.1",
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
+        "@noble/curves": "1.8.1",
+        "@noble/hashes": "1.7.1",
         "@types/node": "22.7.5",
         "aes-js": "4.0.0-beta.5",
         "tslib": "2.7.0",
@@ -94,24 +94,27 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
+      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.3.2"
+        "@noble/hashes": "1.7.1"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 16"
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@adraffy/ens-normalize": "1.10.1",
-    "@noble/curves": "1.2.0",
-    "@noble/hashes": "1.3.2",
+    "@noble/curves": "1.8.1",
+    "@noble/hashes": "1.7.1",
     "@types/node": "22.7.5",
     "aes-js": "4.0.0-beta.5",
     "tslib": "2.7.0",

--- a/src.ts/crypto/signing-key.ts
+++ b/src.ts/crypto/signing-key.ts
@@ -7,8 +7,8 @@
 import { secp256k1 } from "@noble/curves/secp256k1";
 
 import {
-    concat, dataLength, getBytes, getBytesCopy, hexlify, toBeHex,
-    assertArgument
+    assertArgument,
+    concat, dataLength, getBytes, getBytesCopy, hexlify, toBeHex
 } from "../utils/index.js";
 
 import { Signature } from "./signature.js";
@@ -58,11 +58,13 @@ export class SigningKey {
     /**
      *  Return the signature of the signed %%digest%%.
      */
-    sign(digest: BytesLike): Signature {
+    sign(digest: BytesLike, extraEntropy: boolean | BytesLike = false): Signature {
         assertArgument(dataLength(digest) === 32, "invalid digest length", "digest", digest);
+        if (extraEntropy && typeof extraEntropy !== 'boolean') extraEntropy = getBytesCopy(extraEntropy);
 
         const sig = secp256k1.sign(getBytesCopy(digest), getBytesCopy(this.#privateKey), {
-            lowS: true
+            lowS: true,
+            extraEntropy
         });
 
         return Signature.from({


### PR DESCRIPTION
This change adds optional `extraEntropy` argument to sign(). It is false by default. When it is true, random bytes are auto-added. It can also be set to a specific string or uint8array.

There is also a dep upgrade:

- Changes in curves: [changelog](https://github.com/paulmillr/noble-curves/releases), [diff](https://github.com/paulmillr/noble-curves/compare/1.2.0...1.8.1)
- Changes in hashes: [changelog](https://github.com/paulmillr/noble-hashes/releases), [diff](https://github.com/paulmillr/noble-hashes/compare/1.3.2...1.7.1)
- Other packages have already upgraded to newer libraries, upgrading in ethers will bring security improvements and dep deduplication

Background:

- gh-4885
- Elliptic.js private key leak preventable with the fix https://github.com/indutny/elliptic/security/advisories/GHSA-vjh7-7g9h-fjfh
- My blog post on the issue: https://paulmillr.com/posts/deterministic-signatures/
- ethresearch blog post: https://ethresear.ch/t/hedged-signatures-ftw/21757
- Fault attacks / attacks against deterministic signatures have been discussed in [SH16](https://www.cs2.deib.polimi.it/slides_16/01_Seuschek_Deterministic_Signatures.pdf), [BP16](https://link.springer.com/chapter/10.1007/978-3-319-44524-3_11), [RP17](https://romailler.ch/ddl/10.1109_FDTC.2017.12_eddsa.pdf), [ABFJLM17](https://eprint.iacr.org/2017/975), [SBBDS17](https://eprint.iacr.org/2017/985.pdf), [PSSLR17](https://eprint.iacr.org/2017/1014), [SB18](https://nielssamwel.nl/papers/africacrypt2018_fault.pdf), [WPB19](https://eprint.iacr.org/2019/358.pdf), [AOTZ19](https://eprint.iacr.org/2019/956), [FG19](https://eprint.iacr.org/2019/1053).
- Hedged signatures specs: RFC 6979 section 3.6, [BIP340 in 2018-2020](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#user-content-Default_Signing) ("Using unpredictable randomness additionally increases protection against other side-channel attacks, and is recommended whenever available."), [CFRG draft in 2022](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-det-sigs-with-noise-04)
