### PR TITLE
docs: fix Log.transactionIndex documentation

### DIFF
--- a/src.ts/providers/provider.ts
+++ b/src.ts/providers/provider.ts
@@ -838,7 +838,7 @@ export class Log implements LogParams {
     readonly index!: number;
 
     /**
-     *  The index within the transaction of this log.
+     *  The index of the transaction that generated this log within the block.
      */
     readonly transactionIndex!: number;
 


### PR DESCRIPTION
# Fix incorrect documentation for Log.transactionIndex

## Description
This PR fixes the incorrect documentation for the `transactionIndex` property in the `Provider.Log`. The current documentation states that it represents "The index within the transaction of this log", which is incorrect.

According to the [EIP-1474](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md) specification, in the transaction receipt logs:
- `logIndex`: The index of the log in the block
- `transactionIndex`: The index of the transaction in the block

## Related Issue
This PR addresses the documentation issue raised in [#4960](https://github.com/ethers-io/ethers.js/issues/4960). While the issue submitter's understanding of the properties was incorrect, they did identify that the documentation for `transactionIndex` was misleading and needed to be updated to match the EVM RPC specification.

## Testing
No code changes were made, only documentation was updated. The implementation remains correct, only the documentation needed to be fixed to match the EVM RPC specification.