### PR TITLE
fix: `_getBytes()` regex fails for large strings

### DIFF
--- a/src.ts/utils/data.ts
+++ b/src.ts/utils/data.ts
@@ -31,7 +31,7 @@ function _getBytes(value: BytesLike, name?: string, copy?: boolean): Uint8Array 
         return value;
     }
 
-    if (typeof(value) === "string" && value.match(/^0x(?:[0-9a-f][0-9a-f])*$/i)) {
+    if (typeof(value) === "string" && !(value.length & 1) && value.match(/^0x[0-9a-f]*$/i)) {
         const result = new Uint8Array((value.length - 2) / 2);
         let offset = 2;
         for (let i = 0; i < result.length; i++) {


### PR DESCRIPTION
- simplify hex regex