### PR TITLE
Faster receipt return with default parameters

### DIFF
--- a/src.ts/providers/provider.ts
+++ b/src.ts/providers/provider.ts
@@ -1598,7 +1598,7 @@ export class TransactionResponse implements TransactionLike<string>, Transaction
         if (confirms === 0) { return checkReceipt(receipt); }
 
         if (receipt) {
-            if ((await receipt.confirmations()) >= confirms) {
+            if (confirms === 1 || (await receipt.confirmations()) >= confirms) {
                 return checkReceipt(receipt);
             }
 


### PR DESCRIPTION
Existence of a receipt implies at least 1 confirmation. So we don't need to check the latest block number.

This improves latency as it avoids one RPC call.