### PR TITLE
When CCIP-Read is enabled and tx is rejected, check length of data before slicing

### DIFF
--- a/src.ts/providers/abstract-provider.ts
+++ b/src.ts/providers/abstract-provider.ts
@@ -986,7 +986,7 @@ export class AbstractProvider implements Provider {
 
          } catch (error: any) {
              // CCIP Read OffchainLookup
-             if (!this.disableCcipRead && isCallException(error) && error.data && attempt >= 0 && blockTag === "latest" && transaction.to != null && dataSlice(error.data, 0, 4) === "0x556f1830") {
+             if (!this.disableCcipRead && isCallException(error) && error.data && attempt >= 0 && blockTag === "latest" && transaction.to != null && getBytes(error.data).length >= 4 && dataSlice(error.data, 0, 4) === "0x556f1830") {
                  const data = error.data;
 
                  const txSender = await resolveAddress(transaction.to, this);


### PR DESCRIPTION
Fixes #4982

Call exceptions that are not CCIP-Read and returns `data: 0x` (less than 4 bytes) throws an unrelated error.