### PR TITLE
fix(docs): correct contract event filter example

### DIFF
--- a/docs.wrm/getting-started.wrm
+++ b/docs.wrm/getting-started.wrm
@@ -419,7 +419,7 @@ _code: listen for ERC-20 events  @lang<script>
   })
 
   // Listen for any Transfer to "ethers.eth"
-  filter = contract.filters.Transfer("ethers.eth")
+  filter = contract.filters.Transfer(null, "ethers.eth")
   contract.on(filter, (from, to, amount, event) => {
     // `to` will always be equal to the address of "ethers.eth"
   });
@@ -462,7 +462,7 @@ _code: query historic ERC-20 events  @lang<javascript>
   //_result:
 
   // Query all time for any transfer to ethers.eth
-  filter = contract.filters.Transfer("ethers.eth")
+  filter = contract.filters.Transfer(null, "ethers.eth")
   events = await contract.queryFilter(filter)
 
   // The first matching event


### PR DESCRIPTION
## Description

This PR fixes a documentation error in the getting-started.wrm file where the example for filtering Transfer events was inconsistent with its comment.

The comment states "Listen for any Transfer to 'ethers.eth'", but the code example was incorrectly using `contract.filters.Transfer("ethers.eth")`, which actually filters for transfers FROM ethers.eth, not TO it.

## Changes

- Modified the filter examples to use `contract.filters.Transfer(null, "ethers.eth")` which correctly filters for transfers TO ethers.eth
- Updated both the event listening example and the query history example for consistency

## Fixes

Fixes #4984 

## Note

This PR addresses only the filter parameter inconsistency. The issue also mentions ContractEventPayload callbacks, which is a valid feature in v6 but not addressed in this particular PR since it would require more extensive documentation changes.