### PR TITLE
docs: Add migration guide for lastBaseFeePerGas removal in v6

### DIFF
--- a/docs.wrm/migrating.wrm
+++ b/docs.wrm/migrating.wrm
@@ -263,6 +263,32 @@ _code: Getting legacy gas price  @lang<script>
   // v6
   (await provider.getFeeData()).gasPrice
 
+_null:
+
+The `lastBaseFeePerGas` field has been removed from the `FeeData` object in v6.
+This field was commonly used in v5 to calculate target gas prices by adding it
+to `maxPriorityFeePerGas`. In v6, this calculation is handled automatically.
+
+_code: Base fee handling  @lang<script>
+  // v5: Manual calculation using lastBaseFeePerGas
+  const feeData = await provider.getFeeData()
+  const targetGasPrice = feeData.maxPriorityFeePerGas.add(feeData.lastBaseFeePerGas)
+
+  // v6: Use maxFeePerGas (automatically calculated using EIP-1559 heuristics)
+  const feeData = await provider.getFeeData()
+  const targetGasPrice = feeData.maxFeePerGas
+
+  // v6: Alternative - get base fee from latest block if needed
+  const block = await provider.getBlock("latest")
+  const baseFeePerGas = block.baseFeePerGas  // This is the equivalent of lastBaseFeePerGas
+
+  // v6: Manual calculation (if you need the old behavior)
+  const [feeData, block] = await Promise.all([
+    provider.getFeeData(),
+    provider.getBlock("latest")
+  ])
+  const targetGasPrice = feeData.maxPriorityFeePerGas + block.baseFeePerGas
+
 
 _subsection: Signatures  @<migrate-signatures>
 


### PR DESCRIPTION
# Add Migration Guide for FeeData.lastBaseFeePerGas

## Description
This PR adds documentation to the migration guide explaining the removal of `lastBaseFeePerGas` from the `FeeData` object in v6 and provides clear migration paths for users upgrading from v5.

## Changes
- Added a new section in the migration guide about `lastBaseFeePerGas` changes
- Documented multiple migration approaches:
  1. Using `maxFeePerGas` (recommended approach)
  2. Getting `baseFeePerGas` directly from the latest block
  3. Manual calculation for backward compatibility
- Provided code examples for each migration path

## Context
In ethers.js v5, users commonly calculated target gas prices by adding `lastBaseFeePerGas` to `maxPriorityFeePerGas`. In v6, this calculation is handled automatically through the `maxFeePerGas` field, which follows EIP-1559 heuristics.

## Related Issues
Fixes #4871
