### PR TITLE
fix: Update chainId 42 network from Kovan to LUKSO

### DIFF
--- a/src.ts/providers/network.ts
+++ b/src.ts/providers/network.ts
@@ -386,7 +386,7 @@ function injectCommonNetworks(): void {
     registerEth("ropsten", 3, { ensNetwork: 3 });
     registerEth("rinkeby", 4, { ensNetwork: 4 });
     registerEth("goerli", 5, { ensNetwork: 5 });
-    registerEth("kovan", 42, { ensNetwork: 42 });
+    registerEth("lukso", 42, { ensNetwork: 42 });
     registerEth("sepolia", 11155111, { ensNetwork: 11155111 });
     registerEth("holesky", 17000, { ensNetwork: 17000 });
 


### PR DESCRIPTION
# Update chainId 42 network from Kovan to LUKSO

## Description
Updates the network name for chainId 42 from "Kovan" (deprecated) to "LUKSO" (current mainnet). This change reflects that the Kovan testnet is deprecated and chainId 42 is now being used by LUKSO mainnet.

## Changes
- Changed network name from "kovan" to "lukso" for chainId 42
- Maintained existing ENS network configuration

## Context
The Kovan testnet has been deprecated, and chainId 42 is now being used by LUKSO mainnet. The current implementation incorrectly shows "Kovan" for chainId 42, which could mislead developers and users.

For more information about LUKSO mainnet parameters, see: https://docs.lukso.tech/networks/mainnet/parameters

## Related Issues
Fixes #4531