### PR TITLE
Extend Log type with optional timestamp property

### DIFF
--- a/src.ts/providers/format.ts
+++ b/src.ts/providers/format.ts
@@ -101,6 +101,7 @@ const _formatLog = object({
     topics: arrayOf(formatHash),
     transactionHash: formatHash,
     transactionIndex: getNumber,
+    timestamp: allowNull(getNumber),
 }, {
     index: [ "logIndex" ]
 });
@@ -156,6 +157,7 @@ const _formatReceiptLog = object({
     data: formatData,
     index: getNumber,
     blockHash: formatHash,
+    timestamp: allowNull(getNumber),
 }, {
     index: [ "logIndex" ]
 });

--- a/src.ts/providers/formatting.ts
+++ b/src.ts/providers/formatting.ts
@@ -173,6 +173,13 @@ export interface LogParams {
      *  The transaction index of this log.
      */
     transactionIndex: number;
+
+    /**
+     *  The timestamp of the block that included this log (optional).
+     *  This is supported by newer versions of Geth as per updated
+     *  eth_getLogs specification.
+     */
+    timestamp?: number;
 }
 
 

--- a/src.ts/providers/provider.ts
+++ b/src.ts/providers/provider.ts
@@ -858,6 +858,13 @@ export class Log implements LogParams {
     readonly transactionIndex!: number;
 
     /**
+     *  The timestamp of the block that included this log (optional).
+     *  This is supported by newer versions of Geth as per updated
+     *  eth_getLogs specification.
+     */
+    readonly timestamp?: number;
+
+    /**
      *  @_ignore:
      */
     constructor(log: LogParams, provider: Provider) {
@@ -878,6 +885,7 @@ export class Log implements LogParams {
 
             index: log.index,
             transactionIndex: log.transactionIndex,
+            timestamp: log.timestamp,
         });
     }
 
@@ -887,13 +895,13 @@ export class Log implements LogParams {
     toJSON(): any {
         const {
             address, blockHash, blockNumber, data, index,
-            removed, topics, transactionHash, transactionIndex
+            removed, topics, transactionHash, transactionIndex, timestamp
         } = this;
 
         return {
             _type: "log",
             address, blockHash, blockNumber, data, index,
-            removed, topics, transactionHash, transactionIndex
+            removed, topics, transactionHash, transactionIndex, timestamp
         };
     }
 


### PR DESCRIPTION
## Description

Adds optional `timestamp` property to `Log` type to support Geth v1.16.0+ `eth_getLogs` responses that now include block timestamps.

## Changes

- Added `timestamp?: number` to `LogParams` interface
- Updated log formatters to handle timestamp field
- Updated `Log` class with timestamp property and JSON serialization

## References

- Fixes #5011