### PR TITLE
fix(docs): updated rebranded name and link of Taho project (formerly Tally)

### DIFF
--- a/docs.wrm/index.wrm
+++ b/docs.wrm/index.wrm
@@ -4,7 +4,7 @@ The ethers.js library aims to be a complete and compact library
 for interacting with the Ethereum Blockchain and its ecosystem.
 
 It is often used to create decentralized applications (dapps),
-wallets (such as [[link-metamask]] and [[link-tally]]) and
+wallets (such as [[link-metamask]] and [[link-taho]]) and
 other tools and simple scripts that require reading and writing
 to the blockchain.
 

--- a/docs.wrm/links/projects.txt
+++ b/docs.wrm/links/projects.txt
@@ -22,7 +22,7 @@ link-quicknode [QuickNode](https://www.quicknode.com/ethers)
 link-react-native [React Native](https://reactnative.dev)
 link-semver [semver](https://semver.org)
 link-solidity [Solidity](https://solidity.readthedocs.io/)
-link-tally [Tally](https://tallyho.org)
+link-taho [Taho](https://taho.xyz/)
 
 # Project-specific
 link-alchemy-signup [Alchemy Signup](https://dashboard.alchemyapi.io/signup?referral=55a35117-028e-4b7c-9e47-e275ad0acc6d)


### PR DESCRIPTION
### Description

This PR replaces the old name and link of Taho Project (formerly Tally), mentionned in the main page of the v6 docs.

### Changes

- name of Taho's link variable
- title and link of Taho's website