### PR TITLE
Add Otterscan (ots_) Provider

### DIFF
--- a/src.ts/_tests/test-providers-otterscan.ts
+++ b/src.ts/_tests/test-providers-otterscan.ts
@@ -1,0 +1,273 @@
+import assert from "assert";
+
+import {
+    FetchRequest,
+    OtterscanProvider,
+    JsonRpcProvider,
+    type OtsInternalOp,
+    type OtsBlockDetails,
+    type OtsBlockTxPage,
+    type OtsSearchPage,
+    type OtsContractCreator,
+} from "../index.js";
+
+describe("Test Otterscan Provider", function() {
+    // Mock OTS responses for testing
+    function createMockOtsProvider() {
+        const req = new FetchRequest("http://localhost:8545/");
+        
+        req.getUrlFunc = async (_req, signal) => {
+            const bodyStr = typeof _req.body === "string" ? _req.body : new TextDecoder().decode(_req.body || new Uint8Array());
+            const request = JSON.parse(bodyStr || "{}");
+            
+            let result: any;
+            
+            switch (request.method) {
+                case "ots_getApiLevel":
+                    result = 8;
+                    break;
+                case "ots_hasCode":
+                    // Mock: return true for non-zero addresses
+                    result = request.params[0] !== "0x0000000000000000000000000000000000000000";
+                    break;
+                case "ots_getInternalOperations":
+                    result = [{
+                        type: 0,
+                        from: "0x1234567890123456789012345678901234567890",
+                        to: "0x0987654321098765432109876543210987654321",
+                        value: "0x1000000000000000000"
+                    }];
+                    break;
+                case "ots_getTransactionError":
+                    result = "0x";
+                    break;
+                case "ots_traceTransaction":
+                    result = { calls: [] };
+                    break;
+                case "ots_getBlockDetails":
+                    result = {
+                        block: {
+                            hash: "0x123abc",
+                            number: "0x1000"
+                        },
+                        transactionCount: 5,
+                        totalFees: "0x5000000000000000"
+                    };
+                    break;
+                case "ots_getBlockTransactions":
+                    result = {
+                        transactions: [{
+                            hash: "0x456def",
+                            from: "0x1111111111111111111111111111111111111111",
+                            to: "0x2222222222222222222222222222222222222222",
+                            value: "0x1000000000000000000"
+                        }],
+                        receipts: [{
+                            status: "0x1",
+                            gasUsed: "0x5208"
+                        }]
+                    };
+                    break;
+                case "ots_searchTransactionsBefore":
+                case "ots_searchTransactionsAfter":
+                    result = {
+                        txs: [{
+                            hash: "0x789ghi",
+                            blockNumber: "0x1000"
+                        }],
+                        receipts: [{
+                            status: "0x1"
+                        }],
+                        firstPage: true,
+                        lastPage: false
+                    };
+                    break;
+                case "ots_getTransactionBySenderAndNonce":
+                    result = "0xabcdef123456789";
+                    break;
+                case "ots_getContractCreator":
+                    result = {
+                        hash: "0x987654321",
+                        creator: "0x1111111111111111111111111111111111111111"
+                    };
+                    break;
+                case "eth_chainId":
+                    result = "0x1";
+                    break;
+                case "eth_blockNumber":
+                    result = "0x1000";
+                    break;
+                default:
+                    throw new Error(`Unsupported method: ${request.method}`);
+            }
+            
+            const response = {
+                id: request.id,
+                jsonrpc: "2.0",
+                result
+            };
+            
+            return {
+                statusCode: 200,
+                statusMessage: "OK",
+                headers: { "content-type": "application/json" },
+                body: new TextEncoder().encode(JSON.stringify(response))
+            };
+        };
+        
+        return new OtterscanProvider(req, 1, { staticNetwork: true });
+    }
+
+    it("should extend JsonRpcProvider", function() {
+        const provider = createMockOtsProvider();
+        assert(provider instanceof OtterscanProvider, "should be OtterscanProvider instance");
+        assert(provider instanceof JsonRpcProvider, "should extend JsonRpcProvider");
+    });
+
+    it("should get OTS API level", async function() {
+        const provider = createMockOtsProvider();
+        const apiLevel = await provider.otsApiLevel();
+        assert.strictEqual(apiLevel, 8, "should return API level 8");
+    });
+
+    it("should check if address has code", async function() {
+        const provider = createMockOtsProvider();
+        
+        const hasCodeTrue = await provider.hasCode("0x1234567890123456789012345678901234567890");
+        assert.strictEqual(hasCodeTrue, true, "should return true for non-zero address");
+        
+        const hasCodeFalse = await provider.hasCode("0x0000000000000000000000000000000000000000");
+        assert.strictEqual(hasCodeFalse, false, "should return false for zero address");
+    });
+
+    it("should get internal operations", async function() {
+        const provider = createMockOtsProvider();
+        const internalOps = await provider.getInternalOperations("0x123");
+        
+        assert(Array.isArray(internalOps), "should return array");
+        assert.strictEqual(internalOps.length, 1, "should have one operation");
+        
+        const op = internalOps[0];
+        assert.strictEqual(op.type, 0, "should have type 0");
+        assert.strictEqual(op.from, "0x1234567890123456789012345678901234567890", "should have correct from");
+        assert.strictEqual(op.to, "0x0987654321098765432109876543210987654321", "should have correct to");
+        assert.strictEqual(op.value, "0x1000000000000000000", "should have correct value");
+    });
+
+    it("should get transaction error data", async function() {
+        const provider = createMockOtsProvider();
+        const errorData = await provider.getTransactionErrorData("0x123");
+        assert.strictEqual(errorData, "0x", "should return empty error data");
+    });
+
+    it("should get transaction revert reason", async function() {
+        const provider = createMockOtsProvider();
+        const revertReason = await provider.getTransactionRevertReason("0x123");
+        assert.strictEqual(revertReason, null, "should return null for no error");
+    });
+
+    it("should trace transaction", async function() {
+        const provider = createMockOtsProvider();
+        const trace = await provider.traceTransaction("0x123");
+        assert(typeof trace === "object", "should return trace object");
+        assert(Array.isArray(trace.calls), "should have calls array");
+    });
+
+    it("should get block details", async function() {
+        const provider = createMockOtsProvider();
+        const blockDetails = await provider.getBlockDetails(4096);
+        
+        assert(typeof blockDetails === "object", "should return object");
+        assert.strictEqual(blockDetails.transactionCount, 5, "should have transaction count");
+        assert.strictEqual(blockDetails.totalFees, "0x5000000000000000", "should have total fees");
+        assert(blockDetails.block, "should have block data");
+    });
+
+    it("should get block transactions", async function() {
+        const provider = createMockOtsProvider();
+        const blockTxs = await provider.getBlockTransactions(4096, 0, 10);
+        
+        assert(Array.isArray(blockTxs.transactions), "should have transactions array");
+        assert(Array.isArray(blockTxs.receipts), "should have receipts array");
+        assert.strictEqual(blockTxs.transactions.length, 1, "should have one transaction");
+        assert.strictEqual(blockTxs.receipts.length, 1, "should have one receipt");
+    });
+
+    it("should search transactions before", async function() {
+        const provider = createMockOtsProvider();
+        const searchResults = await provider.searchTransactionsBefore("0x123", 4096, 10);
+        
+        assert(Array.isArray(searchResults.txs), "should have txs array");
+        assert(Array.isArray(searchResults.receipts), "should have receipts array");
+        assert.strictEqual(searchResults.firstPage, true, "should be first page");
+        assert.strictEqual(searchResults.lastPage, false, "should not be last page");
+    });
+
+    it("should search transactions after", async function() {
+        const provider = createMockOtsProvider();
+        const searchResults = await provider.searchTransactionsAfter("0x123", 4096, 10);
+        
+        assert(Array.isArray(searchResults.txs), "should have txs array");
+        assert(Array.isArray(searchResults.receipts), "should have receipts array");
+    });
+
+    it("should get transaction by sender and nonce", async function() {
+        const provider = createMockOtsProvider();
+        const txHash = await provider.getTransactionBySenderAndNonce("0x123", 0);
+        assert.strictEqual(txHash, "0xabcdef123456789", "should return transaction hash");
+    });
+
+    it("should get contract creator", async function() {
+        const provider = createMockOtsProvider();
+        const creator = await provider.getContractCreator("0x123");
+        
+        assert(typeof creator === "object", "should return object");
+        assert.strictEqual(creator?.hash, "0x987654321", "should have creation hash");
+        assert.strictEqual(creator?.creator, "0x1111111111111111111111111111111111111111", "should have creator address");
+    });
+
+    it("should ensure OTS capability", async function() {
+        const provider = createMockOtsProvider();
+        
+        // Should not throw
+        await provider.ensureOts(8);
+        
+        // Should throw for higher requirement
+        try {
+            await provider.ensureOts(10);
+            assert.fail("should have thrown for unsupported API level");
+        } catch (error: any) {
+            assert(error.message.includes("ots_getApiLevel"), "should mention API level");
+            assert.strictEqual(error.code, "OTS_UNAVAILABLE", "should have correct error code");
+        }
+    });
+
+    it("should have async iterator for address history", function() {
+        const provider = createMockOtsProvider();
+        const iterator = provider.iterateAddressHistory("0x123", "before", 4096);
+        
+        assert(typeof iterator[Symbol.asyncIterator] === "function", "should be async iterable");
+    });
+
+    it("should properly type return values", async function() {
+        const provider = createMockOtsProvider();
+        
+        // Test TypeScript typing works correctly
+        const apiLevel: number = await provider.otsApiLevel();
+        const hasCode: boolean = await provider.hasCode("0x123");
+        const internalOps: OtsInternalOp[] = await provider.getInternalOperations("0x123");
+        const blockDetails: OtsBlockDetails = await provider.getBlockDetails(4096);
+        const blockTxs: OtsBlockTxPage = await provider.getBlockTransactions(4096, 0, 10);
+        const searchResults: OtsSearchPage = await provider.searchTransactionsBefore("0x123", 4096, 10);
+        const creator: OtsContractCreator | null = await provider.getContractCreator("0x123");
+        
+        // Basic type assertions
+        assert.strictEqual(typeof apiLevel, "number");
+        assert.strictEqual(typeof hasCode, "boolean");
+        assert(Array.isArray(internalOps));
+        assert(typeof blockDetails === "object");
+        assert(typeof blockTxs === "object" && Array.isArray(blockTxs.transactions));
+        assert(typeof searchResults === "object" && Array.isArray(searchResults.txs));
+        assert(creator === null || typeof creator === "object");
+    });
+});

--- a/src.ts/ethers.ts
+++ b/src.ts/ethers.ts
@@ -66,7 +66,7 @@ export {
     AbstractProvider,
 
     FallbackProvider,
-    JsonRpcApiProvider, JsonRpcProvider, JsonRpcSigner,
+    JsonRpcApiProvider, JsonRpcProvider, JsonRpcSigner, OtterscanProvider,
 
     BrowserProvider,
 
@@ -175,7 +175,9 @@ export type {
     ContractRunner, DebugEventBrowserProvider, Eip1193Provider,
     Eip6963ProviderInfo, EventFilter, Filter, FilterByBlockHash,
     GasCostParameters, JsonRpcApiProviderOptions, JsonRpcError,
-    JsonRpcPayload, JsonRpcResult, JsonRpcTransactionRequest, LogParams,
+    JsonRpcPayload, JsonRpcResult, JsonRpcTransactionRequest,
+    Hex, OtsInternalOp, OtsBlockDetails, OtsBlockTxPage, OtsSearchPage, OtsContractCreator,
+    LogParams,
     MinedBlock, MinedTransactionResponse, Networkish, OrphanFilter,
     PerformActionFilter, PerformActionRequest, PerformActionTransaction,
     PreparedTransactionRequest, ProviderEvent, Subscriber, Subscription,

--- a/src.ts/providers/index.ts
+++ b/src.ts/providers/index.ts
@@ -57,6 +57,8 @@ export {
 export { FallbackProvider } from "./provider-fallback.js";
 export { JsonRpcApiProvider, JsonRpcProvider, JsonRpcSigner } from "./provider-jsonrpc.js"
 
+export { OtterscanProvider } from "./provider-otterscan.js";
+
 export { BrowserProvider } from "./provider-browser.js";
 
 export { AlchemyProvider } from "./provider-alchemy.js";
@@ -126,6 +128,15 @@ export type {
     JsonRpcApiProviderOptions,
     JsonRpcTransactionRequest,
 } from "./provider-jsonrpc.js";
+
+export type {
+    Hex,
+    OtsInternalOp,
+    OtsBlockDetails,
+    OtsBlockTxPage,
+    OtsSearchPage,
+    OtsContractCreator
+} from "./provider-otterscan.js";
 
 export type {
     WebSocketCreator, WebSocketLike

--- a/src.ts/providers/provider-otterscan.ts
+++ b/src.ts/providers/provider-otterscan.ts
@@ -1,0 +1,321 @@
+/**
+ *  The Otterscan provider extends JsonRpcProvider to provide
+ *  specialized methods for interacting with Erigon nodes that expose
+ *  the ots_* JSON-RPC methods.
+ *
+ *  These methods are optimized for blockchain explorers and provide
+ *  efficient access to transaction details, internal operations,
+ *  and paginated transaction history.
+ *
+ * @_section: api/providers/otterscan:Otterscan Provider  [about-otterscanProvider]
+ */
+
+import { Interface } from "../abi/index.js";
+import { dataSlice } from "../utils/index.js";
+import { JsonRpcProvider } from "./provider-jsonrpc.js";
+
+import type { JsonRpcApiProviderOptions } from "./provider-jsonrpc.js";
+import type { Networkish } from "./network.js";
+import type { FetchRequest } from "../utils/index.js";
+
+export type Hex = `0x${string}`;
+
+/**
+ * Internal operation types returned by ots_getInternalOperations
+ */
+export interface OtsInternalOp {
+    /** Operation type: 0=transfer, 1=selfdestruct, 2=create, 3=create2 */
+    type: 0 | 1 | 2 | 3;
+    /** Source address */
+    from: string;
+    /** Target address (null for self-destruct operations) */
+    to: string | null;
+    /** Value transferred (hex quantity) */
+    value: Hex;
+}
+
+/**
+ * Block details with issuance and fee information
+ */
+export interface OtsBlockDetails {
+    /** Raw block data */
+    block: any;
+    /** Number of transactions in the block */
+    transactionCount: number;
+    /** Block reward information (optional) */
+    issuance?: {
+        blockReward: Hex;
+        uncleReward: Hex;
+        issuance: Hex;
+    };
+    /** Total fees collected in the block */
+    totalFees?: Hex;
+}
+
+/**
+ * Paginated block transactions with receipts
+ */
+export interface OtsBlockTxPage {
+    /** Transaction bodies with input truncated to 4-byte selector */
+    transactions: Array<any>;
+    /** Receipts with logs and bloom set to null */
+    receipts: Array<any>;
+}
+
+/**
+ * Paginated search results for address transaction history
+ */
+export interface OtsSearchPage {
+    /** Array of transactions */
+    txs: Array<any>;
+    /** Array of corresponding receipts */
+    receipts: Array<any>;
+    /** Whether this is the first page */
+    firstPage: boolean;
+    /** Whether this is the last page */
+    lastPage: boolean;
+}
+
+/**
+ * Contract creator information
+ */
+export interface OtsContractCreator {
+    /** Transaction hash where contract was created */
+    hash: string;
+    /** Address of the contract creator */
+    creator: string;
+}
+
+/**
+ * The OtterscanProvider extends JsonRpcProvider to add support for
+ * Erigon's OTS (Otterscan) namespace methods.
+ * 
+ * These methods provide efficient access to blockchain data optimized
+ * for explorer applications.
+ * 
+ * **Note**: OTS methods are only available on Erigon nodes with the
+ * ots namespace enabled via --http.api "eth,erigon,trace,ots"
+ */
+export class OtterscanProvider extends JsonRpcProvider {
+    
+    constructor(url?: string | FetchRequest, network?: Networkish, options?: JsonRpcApiProviderOptions) {
+        super(url, network, options);
+    }
+
+    /**
+     * Get the OTS API level supported by the node
+     * @returns The API level number
+     */
+    async otsApiLevel(): Promise<number> {
+        return await this.send("ots_getApiLevel", []);
+    }
+
+    /**
+     * Check if an address has code at a specific block
+     * @param address - The address to check
+     * @param blockTag - Block number or "latest"
+     * @returns True if address has code
+     */
+    async hasCode(address: string, blockTag: string | number | "latest" = "latest"): Promise<boolean> {
+        const blockNumber = blockTag === "latest" ? "latest" : Number(blockTag);
+        return await this.send("ots_hasCode", [address, blockNumber]);
+    }
+
+    /**
+     * Get internal operations (transfers, creates, selfdestructs) for a transaction
+     * @param txHash - Transaction hash
+     * @returns Array of internal operations
+     */
+    async getInternalOperations(txHash: string): Promise<OtsInternalOp[]> {
+        return await this.send("ots_getInternalOperations", [txHash]);
+    }
+
+    /**
+     * Get raw revert data for a failed transaction
+     * @param txHash - Transaction hash
+     * @returns Raw revert data as hex string, "0x" if no error
+     */
+    async getTransactionErrorData(txHash: string): Promise<Hex> {
+        return await this.send("ots_getTransactionError", [txHash]);
+    }
+
+    /**
+     * Get human-readable revert reason for a failed transaction
+     * @param txHash - Transaction hash
+     * @param customAbi - Optional custom ABI for decoding custom errors
+     * @returns Decoded error message or null if no error
+     */
+    async getTransactionRevertReason(txHash: string, customAbi?: any[]): Promise<string | null> {
+        const data: string = await this.getTransactionErrorData(txHash);
+        if (data === "0x") return null;
+
+        // Try to decode Error(string) - the most common case
+        const ERROR_SIG = "0x08c379a0";
+        if (data.startsWith(ERROR_SIG)) {
+            try {
+                const iface = new Interface(["error Error(string)"]);
+                const decoded = iface.decodeErrorResult("Error", data);
+                return String(decoded[0]);
+            } catch {
+                // Fall through to other attempts
+            }
+        }
+
+        // Try custom error set if provided
+        if (customAbi) {
+            try {
+                const iface = new Interface(customAbi);
+                const parsed = iface.parseError(data);
+                if (parsed) {
+                    return `${parsed.name}(${parsed.args.map((a) => {
+                        try {
+                            return JSON.stringify(a);
+                        } catch {
+                            return String(a);
+                        }
+                    }).join(",")})`;
+                }
+            } catch {
+                // Fall through to selector display
+            }
+        }
+
+        // Last resort: show 4-byte selector
+        return `revert data selector ${dataSlice(data, 0, 4)}`;
+    }
+
+    /**
+     * Get execution trace for a transaction
+     * @param txHash - Transaction hash
+     * @returns Trace data
+     */
+    async traceTransaction(txHash: string): Promise<any> {
+        return await this.send("ots_traceTransaction", [txHash]);
+    }
+
+    /**
+     * Get detailed block information including issuance and fees
+     * @param blockNumber - Block number
+     * @returns Block details with additional metadata
+     */
+    async getBlockDetails(blockNumber: number): Promise<OtsBlockDetails> {
+        return await this.send("ots_getBlockDetails", [blockNumber]);
+    }
+
+    /**
+     * Get paginated transactions for a block
+     * @param blockNumber - Block number
+     * @param page - Page number (0-based)
+     * @param pageSize - Number of transactions per page
+     * @returns Page of transactions and receipts
+     */
+    async getBlockTransactions(blockNumber: number, page: number, pageSize: number): Promise<OtsBlockTxPage> {
+        return await this.send("ots_getBlockTransactions", [blockNumber, page, pageSize]);
+    }
+
+    /**
+     * Search for transactions before a specific block for an address
+     * @param address - Address to search for
+     * @param blockNumber - Starting block number
+     * @param pageSize - Maximum results to return
+     * @returns Page of transactions
+     */
+    async searchTransactionsBefore(address: string, blockNumber: number, pageSize: number): Promise<OtsSearchPage> {
+        return await this.send("ots_searchTransactionsBefore", [address, blockNumber, pageSize]);
+    }
+
+    /**
+     * Search for transactions after a specific block for an address
+     * @param address - Address to search for
+     * @param blockNumber - Starting block number
+     * @param pageSize - Maximum results to return
+     * @returns Page of transactions
+     */
+    async searchTransactionsAfter(address: string, blockNumber: number, pageSize: number): Promise<OtsSearchPage> {
+        return await this.send("ots_searchTransactionsAfter", [address, blockNumber, pageSize]);
+    }
+
+    /**
+     * Get transaction hash by sender address and nonce
+     * @param sender - Sender address
+     * @param nonce - Transaction nonce
+     * @returns Transaction hash or null if not found
+     */
+    async getTransactionBySenderAndNonce(sender: string, nonce: number): Promise<string | null> {
+        return await this.send("ots_getTransactionBySenderAndNonce", [sender, nonce]);
+    }
+
+    /**
+     * Get contract creator information
+     * @param address - Contract address
+     * @returns Creator info or null if not a contract
+     */
+    async getContractCreator(address: string): Promise<OtsContractCreator | null> {
+        return await this.send("ots_getContractCreator", [address]);
+    }
+
+    /**
+     * Verify OTS availability and check minimum API level
+     * @param minLevel - Minimum required API level (default: 0)
+     * @throws Error if OTS is unavailable or API level too low
+     */
+    async ensureOts(minLevel: number = 0): Promise<void> {
+        try {
+            const level = await this.otsApiLevel();
+            if (level < minLevel) {
+                throw new Error(`ots_getApiLevel ${level} < required ${minLevel}`);
+            }
+        } catch (error: any) {
+            const err = new Error(`Erigon OTS namespace unavailable or too old: ${error?.message ?? error}`);
+            (err as any).code = "OTS_UNAVAILABLE";
+            throw err;
+        }
+    }
+
+    /**
+     * Iterate through transaction history for an address
+     * @param address - Address to search
+     * @param direction - Search direction ("before" or "after")
+     * @param startBlock - Starting block number
+     * @param pageSize - Results per page (default: 500)
+     * @yields Object with tx and receipt for each transaction
+     */
+    async *iterateAddressHistory(
+        address: string,
+        direction: "before" | "after",
+        startBlock: number,
+        pageSize: number = 500
+    ): AsyncGenerator<{ tx: any; receipt: any }, void, unknown> {
+        let currentBlock = startBlock;
+
+        while (true) {
+            const page = direction === "before"
+                ? await this.searchTransactionsBefore(address, currentBlock, pageSize)
+                : await this.searchTransactionsAfter(address, currentBlock, pageSize);
+
+            // Yield each transaction with its receipt
+            for (let i = 0; i < page.txs.length; i++) {
+                yield {
+                    tx: page.txs[i],
+                    receipt: page.receipts[i]
+                };
+            }
+
+            // Check if we've reached the end
+            if (page.lastPage) break;
+
+            // Update block cursor for next iteration
+            const lastTx = page.txs[page.txs.length - 1];
+            if (!lastTx) break;
+
+            const nextBlock = Number(lastTx.blockNumber);
+            
+            // Prevent infinite loops from malformed API responses
+            if (nextBlock === currentBlock) {
+                throw new Error(`Iterator stuck on block ${currentBlock}. API returned same block number.`);
+            }
+            
+            currentBlock = nextBlock;
+        }
+    }
+}


### PR DESCRIPTION
Adding a new subclass of JsonRpcProvider supporting erigon's ots_ (Otterscan) methods.  The ots_ namespace provides some very helpful methods, most importantly being able to quickly fetch a list of all transactions belonging to a given address.

If your node supports the ots_ namespace, this provider will give you access to 11 new RPC methods: ots_getApiLevel, ots_hasCode, ots_getInternalOperations, ots_getTransactionError, ots_traceTransaction, ots_getBlockDetails, ots_getBlockTransactions,  ots_searchTransactionsBefore/After, ots_getTransactionBySenderAndNonce, ots_getContractCreator

- Convenience methods: getTransactionRevertReason() (decodes revert data), ensureOts() (making sure you're running an ots_ compatible node), iterateAddressHistory() (async iterator for pagination)
- Full TypeScript support: Proper interfaces for all return types (OtsInternalOp, OtsBlockDetails, etc.)
- 16 new unit tests covering all functionality