### PR TITLE
docs: clarify JsonRpcProvider vs WebSocketProvider behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,5 +136,9 @@ packages designed to further enhance the functionality and experience.
 License
 -------
 
-MIT License (including **all** dependencies).
+MIT License (including **all** dependencies).> Note: JsonRpcProvider uses polling under the hood, while WebSocketProvider
+> enables push-based subscriptions. When low-latency event streams are required
+> (e.g. pending transactions, log subscriptions), a WebSocketProvider is recommended.
+
+
 


### PR DESCRIPTION
This PR adds a short note to the documentation clarifying the behavioral
difference between JsonRpcProvider and WebSocketProvider.

JsonRpcProvider relies on polling under the hood, while WebSocketProvider
enables push-based subscriptions suitable for low-latency event streams
such as pending transactions or log subscriptions.

This helps integrators choose the appropriate provider type when building
real-time UX. Documentation-only change, no code modifications.
