### PR TITLE
added get block receipts

### DIFF
--- a/src.ts/providers/provider-jsonrpc.ts
+++ b/src.ts/providers/provider-jsonrpc.ts
@@ -958,6 +958,12 @@ export abstract class JsonRpcApiProvider extends AbstractProvider {
                     args: [ req.hash ]
                 };
 
+            case "getBlockReceipts":
+                return {
+                    method: "eth_getBlockReceipts",
+                    args: [ req.blockTag ]
+                };
+
             case "call":
                 return {
                     method: "eth_call",

--- a/src.ts/providers/provider.ts
+++ b/src.ts/providers/provider.ts
@@ -2085,6 +2085,11 @@ export interface Provider extends ContractRunner, EventEmitterable<ProviderEvent
     getTransactionReceipt(hash: string): Promise<null | TransactionReceipt>;
 
     /**
+     *  Resolves to all transaction receipts for %%blockTag%%.
+     */
+    getBlockReceipts(blockTag: BlockTag | string): Promise<Array<TransactionReceipt>>;
+
+    /**
      *  Resolves to the result returned by the executions of %%hash%%.
      *
      *  This is only supported on nodes with archive access and with


### PR DESCRIPTION
Trying to get add block receipt added to the ethers library, this is available in many providers to get all the block receipts of a block tag.