### PR TITLE
fix(contract): remove dead code and misleading comment

### DIFF
--- a/src.ts/contract/contract.ts
+++ b/src.ts/contract/contract.ts
@@ -153,9 +153,6 @@ export async function copyOverrides<O extends string = "data" | "to">(arg: any, 
     assertArgument(overrides.data == null || (allowed || [ ]).indexOf("data") >= 0,
       "cannot override data", "overrides.data", overrides.data);
 
-    // Resolve any from
-    if (overrides.from) { overrides.from = overrides.from; }
-
     return <Omit<ContractTransaction, O>>overrides;
 }
 


### PR DESCRIPTION
Removed a no-op assignment to overrides.from and its misleading comment in copyOverrides(). The function cannot resolve addresses here since it lacks a runner/resolver; address resolution correctly occurs at method/fallback populateTransaction where resolveAddress is available. This clarifies intent without changing behavior.