### PR TITLE
fix(provider): align BrowserProvider debug action with docs/types

### DIFF
--- a/src.ts/providers/provider-browser.ts
+++ b/src.ts/providers/provider-browser.ts
@@ -135,7 +135,7 @@ export class BrowserProvider extends JsonRpcApiPollingProvider {
 
         this.#request = async (method: string, params: Array<any> | Record<string, any>) => {
             const payload = { method, params };
-            this.emit("debug", { action: "sendEip1193Request", payload });
+            this.emit("debug", { action: "sendEip1193Payload", payload });
             try {
                 const result = await ethereum.request(payload);
                 this.emit("debug", { action: "receiveEip1193Result", result });


### PR DESCRIPTION
 The BrowserProvider was emitting action "sendEip1193Request" on the "debug" event while the public types and docs specify "sendEip1193Payload". This change switches the emitted action to "sendEip1193Payload" for consistency with the declared DebugEventBrowserProvider and to match the naming convention used by JsonRpc ("sendRpcPayload").