### PR TITLE
fix: correct typo maxFeePerGs to maxFeePerGas

### DIFF
--- a/src.ts/providers/provider-etherscan.ts
+++ b/src.ts/providers/provider-etherscan.ts
@@ -355,7 +355,7 @@ export class EtherscanProvider extends AbstractProvider {
             if (key === "blockTag" && value === "latest") { continue; }
 
             // Quantity-types require no leading zero, unless 0
-            if ((<any>{ type: true, gasLimit: true, gasPrice: true, maxFeePerGs: true, maxPriorityFeePerGas: true, nonce: true, value: true })[key]) {
+            if ((<any>{ type: true, gasLimit: true, gasPrice: true, maxFeePerGas: true, maxPriorityFeePerGas: true, nonce: true, value: true })[key]) {
                 value = toQuantity(value);
 
             } else if (key === "accessList") {


### PR DESCRIPTION
## Summary
Fixed typo in `provider-etherscan.ts` where `maxFeePerGs` should be `maxFeePerGas` in the quantity-types check object.

## Change
```diff
- if ((<any>{ type: true, gasLimit: true, gasPrice: true, maxFeePerGs: true, maxPriorityFeePerGas: true, nonce: true, value: true })[key]) {
+ if ((<any>{ type: true, gasLimit: true, gasPrice: true, maxFeePerGas: true, maxPriorityFeePerGas: true, nonce: true, value: true })[key]) {
```

This ensures `maxFeePerGas` values are properly converted to quantity format when making Etherscan API calls.

Fixes #5080


Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=101010297