### PR TITLE
docs: add beginner-friendly quick example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ packages designed to further enhance the functionality and experience.
 - [GanaceProvider](https://github.com/ethers-io/ext-provider-ganache) - A Provider for in-memory node instances, for fast debugging, testing and simulating blockchain operations
 - [Optimism Utilities](https://github.com/ethers-io/ext-utils-optimism) - A collection of Optimism utilities
 - [LedgerSigner](https://github.com/ethers-io/ext-signer-ledger) - A Signer to interact directly with Ledger Hardware Wallets
-
 ## Quick Example (Beginner Friendly)
 
 ```js
@@ -145,6 +144,7 @@ async function main() {
 }
 
 main();
+
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -132,6 +132,19 @@ packages designed to further enhance the functionality and experience.
 - [Optimism Utilities](https://github.com/ethers-io/ext-utils-optimism) - A collection of Optimism utilities
 - [LedgerSigner](https://github.com/ethers-io/ext-signer-ledger) - A Signer to interact directly with Ledger Hardware Wallets
 
+## Quick Example (Beginner Friendly)
+
+```js
+import { ethers } from "ethers";
+
+const provider = new ethers.JsonRpcProvider("https://rpc.ankr.com/eth");
+
+async function main() {
+  const block = await provider.getBlockNumber();
+  console.log("Current block:", block);
+}
+
+main();
 
 License
 -------


### PR DESCRIPTION
This PR adds a simple ethers.js example to help new developers quickly test provider setup and fetch the current block number.
