### PR TITLE
Correct spelling of NodeJS to Node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ For the latest changes, see the
 Installing
 ----------
 
-**NodeJS**
+**Node.js**
 
 ```
 /home/ricmoo/some_project> npm install ethers


### PR DESCRIPTION
Updated "NodeJS" to the correct and official "Node.js" in the Installing section to improve documentation accuracy and consistency.

No code changes included.