### PR TITLE
docs: fix typo in Provider documentation

### DIFF
--- a/src.ts/providers/provider.ts
+++ b/src.ts/providers/provider.ts
@@ -562,7 +562,7 @@ export class Block implements BlockParams, Iterable<string> {
     readonly excessBlobGas!: null | bigint;
 
     /**
-     *  The miner coinbase address, wihch receives any subsidies for
+     *  The miner coinbase address, which receives any subsidies for
      *  including this block.
      */
     readonly miner!: string;


### PR DESCRIPTION
## Summary

Fixed typo in JSDoc comment for `Block.miner` property:
- Changed "wihch" to "which"

## Issue Reference

Fixes #5079

## Context

The issue mentions two typos in the Provider documentation:
1. "whch can be used" - This only appears in compiled build artifacts (lib.commonjs/providers/index.d.ts and lib.js), not in source code. These will be fixed automatically when the project rebuilds.
2. "wihch receives" - Fixed in this PR (source: src.ts/providers/provider.ts)

## Changes

- **File:** `src.ts/providers/provider.ts`
- **Line:** 561
- **Change:** `wihch` → `which`

This is a documentation-only fix with no functional code changes.