### PR TITLE
feat: handle HTTP 307/308 redirects

### DIFF
--- a/src.ts/utils/fetch.ts
+++ b/src.ts/utils/fetch.ts
@@ -550,6 +550,15 @@ export class FetchRequest implements Iterable<[ key: string, value: string ]> {
             // Things won't get any better on another attempt; abort
             return response;
 
+        } else if (response.statusCode === 307 || response.statusCode === 308) {
+            try {
+                const location = response.headers.location || "";
+                // clone without resetting method/body
+                const redirected = req.clone();
+                redirected.url = location;
+                return redirected.#send(attempt + 1, expires, 0, _request, response);
+            } catch (error) { }
+            return response;
         } else if (response.statusCode === 429) {
 
             // Throttle


### PR DESCRIPTION
## Problem

`FetchRequest` currently only handles 301 and 302 redirects, and its `redirect()` method explicitly requires `GET` and resets the method. When a server responds with 307 (Temporary Redirect) or 308 (Permanent Redirect), ethers treats it as a generic non-2xx response and throws a `SERVER_ERROR`.

This breaks legitimate use cases where JSON-RPC endpoints use 307/308 redirects for load balancing, failover that redirect POST requests to backend nodes.

## HTTP specification context
[RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html) (HTTP Semantics, [Section 15.4.8](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.8) and [Section 15.4.9](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.9)) defines 307 and 308 as method-preserving redirects. The spec is explicit:


> The user agent **MUST NOT** change the request method if it performs an automatic redirection to that URI.

This is the key distinction from 301/302, which historically allowed (and browsers implemented) method downgrading from POST to GET. The 307 and 308 status codes were introduced specifically to address this — 307 as the temporary variant (RFC 7231 §6.4.7) and 308 as the permanent variant (RFC 7538, now folded into RFC 9110).


The redirect status code family per the RFCs:

|  | Permanent | Temporary |
|---|---|---|
| Allows changing POST → GET | 301 | 302 |
| **MUST NOT** change request method | 308 | 307 |

## Current behavior

```
FetchRequest #send():
  - 301/302 → calls redirect() → asserts method === "GET" → follows redirect
  - 307/308 → falls through → assertOk() → throws SERVER_ERROR
```
## Fix

Add a handler for 307/308 between the existing 301/302 and 429 handlers. Instead of calling `redirect()` (which enforces GET), it uses `clone()` to preserve the original method, headers, and body, then updates only the URL:

```ts
} else if (response.statusCode === 307 || response.statusCode === 308) {
    try {
        const location = response.headers.location || "";
        const redirected = req.clone();
        redirected.url = location;
        return redirected.#send(attempt + 1, expires, 0, _request, response);
    } catch (error) { }
    return response;
}
```

This follows the same pattern as the existing 301/302 handler (increment attempt, pass through `_request` for signal tracking, fall back to returning the response on error) while preserving the HTTP semantics that 307/308 require.

