### PR TITLE
fix: reject negative FixedNumber decimals

### DIFF
--- a/src.ts/_tests/test-utils-units.ts
+++ b/src.ts/_tests/test-utils-units.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 
 import { loadTests } from "./utils.js";
 
-import { formatEther, formatUnits, parseEther, parseUnits } from "../index.js";
+import { FixedNumber, formatEther, formatUnits, parseEther, parseUnits } from "../index.js";
 
 import type { TestCaseUnit } from "./types.js";
 
@@ -68,6 +68,34 @@ describe("Tests bad unit conversion", function() {
             parseUnits("3", "foobar");
         }, (error: any) => {
             return error.message.startsWith("invalid unit");
+        });
+    });
+
+    it("correctly fails to convert negative decimal counts", function() {
+        assert.throws(() => {
+            formatUnits(123n, -1);
+        }, (error: any) => {
+            return error.message.startsWith("invalid FixedNumber decimals");
+        });
+
+        assert.throws(() => {
+            parseUnits("1.23", -1);
+        }, (error: any) => {
+            return error.message.startsWith("invalid FixedNumber decimals");
+        });
+    });
+
+    it("correctly fails to create FixedNumber values with negative decimals", function() {
+        assert.throws(() => {
+            FixedNumber.fromValue(1, -1);
+        }, (error: any) => {
+            return error.message.startsWith("invalid FixedNumber decimals");
+        });
+
+        assert.throws(() => {
+            FixedNumber.fromString("1.23", { decimals: -1, width: 128 });
+        }, (error: any) => {
+            return error.message.startsWith("invalid FixedNumber decimals");
         });
     });
 });

--- a/src.ts/utils/fixednumber.ts
+++ b/src.ts/utils/fixednumber.ts
@@ -146,6 +146,7 @@ function getFormat(value?: FixedFormat): _FixedFormat {
     }
 
     assertArgument((width % 8) === 0, "invalid FixedNumber width (not byte aligned)", "format.width", width);
+    assertArgument(decimals >= 0, "invalid FixedNumber decimals (negative)", "format.decimals", decimals);
     assertArgument(decimals <= 80, "invalid FixedNumber decimals (too large)", "format.decimals", decimals);
 
     const name = (signed ? "": "u") + "fixed" + String(width) + "x" + String(decimals);
@@ -567,6 +568,7 @@ export class FixedNumber {
      */
     static fromValue(_value: BigNumberish, _decimals?: Numeric, _format?: FixedFormat): FixedNumber {
         const decimals = (_decimals == null) ? 0: getNumber(_decimals);
+        assertArgument(decimals >= 0, "invalid FixedNumber decimals (negative)", "decimals", decimals);
         const format = getFormat(_format);
 
         let value = getBigInt(_value, "value");


### PR DESCRIPTION
## Summary
- reject negative `FixedNumber` decimal counts before they reach fixed-point scaling helpers
- cover negative decimals for `formatUnits`, `parseUnits`, `FixedNumber.fromValue`, and object-form `FixedNumber.fromString` formats

## Why
`FixedNumber` formats already reject decimals above 80, but object-form formats could still pass negative decimals through. That can produce confusing behavior in callers such as unit conversion, where a negative numeric unit is not a meaningful decimal count. This change makes negative decimals fail with the same argument-validation path used by other invalid fixed formats.

## Validation
- `npm ci`
- `npm run build -- --pretty false`
- `./node_modules/.bin/mocha --trace-warnings --reporter ./reporter.cjs ./lib.esm/_tests/test-utils-units.js --grep "negative decimal|bad unit conversion"`
