### PR TITLE
Emit close events from WebSocketProvider

### DIFF
--- a/src.ts/_tests/test-providers-websocket.ts
+++ b/src.ts/_tests/test-providers-websocket.ts
@@ -1,0 +1,55 @@
+import assert from "assert";
+
+import {
+    WebSocketProvider
+} from "../index.js";
+
+import type {
+    WebSocketLike
+} from "../index.js";
+
+class MockWebSocket implements WebSocketLike {
+    onopen: null | ((...args: Array<any>) => any);
+    onmessage: null | ((...args: Array<any>) => any);
+    onerror: null | ((...args: Array<any>) => any);
+    onclose: null | ((...args: Array<any>) => any);
+    readyState: number;
+
+    constructor() {
+        this.onopen = null;
+        this.onmessage = null;
+        this.onerror = null;
+        this.onclose = null;
+        this.readyState = 1;
+    }
+
+    send(payload: any): void { }
+    close(code?: number, reason?: string): void { }
+}
+
+function stall(duration: number): Promise<void> {
+    return new Promise((resolve) => { setTimeout(resolve, duration); });
+}
+
+describe("Test WebSocketProvider", function() {
+    it("emits close events from the websocket", async function() {
+        const websocket = new MockWebSocket();
+        const provider = new WebSocketProvider(websocket);
+
+        const closeEvent = { code: 1006, reason: "connection lost" };
+        let result: null | typeof closeEvent = null;
+
+        await provider.once("close", (event) => {
+            result = event;
+        });
+
+        const onclose = websocket.onclose;
+        assert.ok(onclose, "websocket has onclose handler");
+        onclose(closeEvent);
+
+        await stall(0);
+        assert.equal(result, closeEvent);
+
+        await provider.destroy();
+    });
+});

--- a/src.ts/providers/abstract-provider.ts
+++ b/src.ts/providers/abstract-provider.ts
@@ -237,6 +237,7 @@ async function getSubscription(_event: ProviderEvent, provider: AbstractProvider
     if (typeof(_event) === "string") {
         switch (_event) {
             case "block":
+            case "close":
             case "debug":
             case "error":
             case "finalized":

--- a/src.ts/providers/provider-websocket.ts
+++ b/src.ts/providers/provider-websocket.ts
@@ -14,6 +14,7 @@ export interface WebSocketLike {
     onopen: null | ((...args: Array<any>) => any);
     onmessage: null | ((...args: Array<any>) => any);
     onerror: null | ((...args: Array<any>) => any);
+    onclose?: null | ((...args: Array<any>) => any);
 
     readyState: number;
 
@@ -72,21 +73,10 @@ export class WebSocketProvider extends SocketProvider {
         this.websocket.onmessage = (message: { data: string }) => {
             this._processMessage(message.data);
         };
-/*
+
         this.websocket.onclose = (event) => {
-            // @TODO: What event.code should we reconnect on?
-            const reconnect = false;
-            if (reconnect) {
-                this.pause(true);
-                if (this.#connect) {
-                    this.#websocket = this.#connect();
-                    this.#websocket.onopen = ...
-                    // @TODO: this requires the super class to rebroadcast; move it there
-                }
-                this._reconnect();
-            }
+            this.emit("close", event);
         };
-*/
     }
 
     async _write(message: string): Promise<void> {

--- a/src.ts/providers/provider.ts
+++ b/src.ts/providers/provider.ts
@@ -1924,6 +1924,9 @@ export interface FilterByBlockHash extends EventFilter {
  *  **``"block"``** - calls the listener with the current block number on each
  *  new block.
  *
+ *  **``"close"``** - calls the listener when a socket provider's underlying
+ *  connection closes.
+ *
  *  **``"error"``** - calls the listener on each async error that occurs during
  *  the event loop, with the error.
  *


### PR DESCRIPTION
## Summary

Fixes #4587.

This makes `WebSocketProvider` surface underlying websocket close events through the provider event API.

## Changes

- Adds optional `onclose` support to `WebSocketLike`
- Emits provider `"close"` when the underlying websocket closes
- Allows `"close"` as a valid provider event
- Documents the `"close"` provider event
- Adds a regression test for websocket close emission

## Testing

- `npm run build-all`
- `npx mocha --trace-warnings --reporter ./reporter.cjs ./lib.esm/_tests/test-providers-websocket.js`
- `npx mocha --reporter ./reporter.cjs ./lib.commonjs/_tests/test-providers-websocket.js`
