### PR TITLE
fix: defer subscriber teardown in emit to prevent WebSocket subscription loss

### DIFF
--- a/src.ts/providers/abstract-provider.ts
+++ b/src.ts/providers/abstract-provider.ts
@@ -1452,8 +1452,21 @@ export class AbstractProvider implements Provider {
         });
 
         if (sub.listeners.length === 0) {
-            if (sub.started) { sub.subscriber.stop(); }
-            this.#subs.delete(sub.tag);
+            // Defer teardown to allow once-listeners (e.g. waitForTransaction)
+            // to re-subscribe before the underlying subscriber is stopped.
+            // Without this, socket-based providers (WebSocket) would
+            // eth_unsubscribe and immediately need to eth_subscribe again on
+            // every block during waitForTransaction, and depending on timing
+            // the re-subscription could be lost entirely, causing subsequent
+            // waitForTransaction calls to hang forever.
+            const tag = sub.tag;
+            this._setTimeout(() => {
+                const s = this.#subs.get(tag);
+                if (s && s.listeners.length === 0) {
+                    if (s.started) { s.subscriber.stop(); }
+                    this.#subs.delete(tag);
+                }
+            }, this.pollingInterval);
         }
 
         return (count > 0);


### PR DESCRIPTION
## Summary
- `WebSocketProvider` silently loses `newHeads` subscription after `once("block")` listener fires
- **Root cause:** `emit()` immediately calls `subscriber.stop()` (which sends `eth_unsubscribe`) when listener count hits 0. But `waitForTransaction` re-registers asynchronously after an `await getTransactionReceipt()`, so the subscription is already gone.
- **Fix:** Defer the subscriber cleanup by `pollingInterval` ms using `_setTimeout()`, then recheck if listener count is still 0 before stopping. This gives `once`-listener callbacks time to re-register.
- Explicit teardown via `off()` and `removeAllListeners()` still stops subscribers immediately
- Deferred timers are cleaned up in `destroy()`

**File:** `src.ts/providers/abstract-provider.ts`

Fixes #5121

## Test plan
- [ ] `waitForTransaction` works correctly across multiple sequential calls
- [ ] WebSocket subscription survives `once("block")` listener lifecycle
- [ ] `provider.destroy()` cleans up all timers and subscriptions
- [ ] `off("block")` still triggers immediate unsubscribe