### PR TITLE
feat: add MYRX-MAINNET (Chain ID 8472)

### DIFF
--- a/src.ts/providers/network.ts
+++ b/src.ts/providers/network.ts
@@ -435,4 +435,5 @@ function injectCommonNetworks(): void {
     registerEth("optimism-sepolia", 11155420, { });
 
     registerEth("xdai", 100, { ensNetwork: 1 });
+    registerEth("myrx", 8472, { });
 }


### PR DESCRIPTION
## Add MYRX-MAINNET (Chain ID 8472)

Adds MYRX-MAINNET sovereign EVM chain (Chain ID 8472) to the built-in network registry.

**Network:** MYRX-MAINNET
**Chain ID:** 8472
**RPC endpoint:** https://rpc.myrxwallet.io
**Block explorer:** https://explorer.myrxwallet.io (EIP-3091)
**Native token:** MRT (MyRx Token, 18 decimals)
**Status:** Mainnet live 2026-05-07
**Operator:** MyRxWallet North America Corporation
**Contact:** developer@myrxwallet.io

Entry added following existing pattern:


Canonical chain data: https://github.com/MyRxWallet/mainnet/blob/main/chain/eip155-8472.json