### PR TITLE
docs: fix source comment typos

### DIFF
--- a/src.ts/abi/fragments.ts
+++ b/src.ts/abi/fragments.ts
@@ -936,8 +936,8 @@ export abstract class Fragment {
     abstract format(format?: FormatType): string;
 
     /**
-     *  Creates a new **Fragment** for %%obj%%, wich can be any supported
-     *  ABI frgament type.
+     *  Creates a new **Fragment** for %%obj%%, which can be any supported
+     *  ABI fragment type.
      */
     static from(obj: any): Fragment {
         if (typeof(obj) === "string") {
@@ -1614,4 +1614,3 @@ export class StructFragment extends NamedFragment {
         return (value && value[internal] === StructFragmentInternal);
     }
 }
-

--- a/src.ts/providers/abstract-signer.ts
+++ b/src.ts/providers/abstract-signer.ts
@@ -53,7 +53,7 @@ async function populate(signer: AbstractSigner, tx: TransactionRequest): Promise
 
 
 /**
- *  An **AbstractSigner** includes most of teh functionality required
+ *  An **AbstractSigner** includes most of the functionality required
  *  to get a [[Signer]] working as expected, but requires a few
  *  Signer-specific methods be overridden.
  *
@@ -311,4 +311,3 @@ export class VoidSigner extends AbstractSigner {
         this.#throwUnsupported("typed-data", "signTypedData");
     }
 }
-

--- a/src.ts/wallet/json-keystore.ts
+++ b/src.ts/wallet/json-keystore.ts
@@ -189,7 +189,7 @@ function getDecryptKdfParams<T>(data: any): KdfParams {
  *
  *  This method will block the event loop (freezing all UI) until decryption
  *  is complete, which can take quite some time, depending on the wallet
- *  paramters and platform.
+ *  parameters and platform.
  */
 export function decryptKeystoreJsonSync(json: string, _password: string | Uint8Array): KeystoreAccount {
     const data = JSON.parse(json);
@@ -386,4 +386,3 @@ export async function encryptKeystoreJson(account: KeystoreAccount, password: st
     const key = await scrypt(passwordBytes, kdf.salt, kdf.N, kdf.r, kdf.p, 64, options.progressCallback);
     return _encryptKeystore(getBytes(key), kdf, account, options);
 }
-


### PR DESCRIPTION
Fixes a few typos in source comments.\n\nSafety notes:\n- Comment-only change\n- No dependencies installed\n- Static check: `git diff --check`