### PR TITLE
Fix keystore KDF validation error argument names

### DIFF
--- a/src.ts/_tests/test-wallet-json.ts
+++ b/src.ts/_tests/test-wallet-json.ts
@@ -184,4 +184,31 @@ describe("Tests Extra JSON Wallet Functions", function() {
         assert.ok(await encryptKeystoreJson(account, password));
     });
 
+    it("tests invalid keystore KDF fields", function() {
+        const json = encryptKeystoreJsonSync(account, password, { scrypt: { N: 64 } });
+        const data = JSON.parse(json);
+
+        const badScrypt = JSON.parse(JSON.stringify(data));
+        badScrypt.Crypto.kdfparams.dklen = 64;
+        assert.throws(() => {
+            decryptKeystoreJsonSync(JSON.stringify(badScrypt), password);
+        }, (error: any) => {
+            return (isError(error, "INVALID_ARGUMENT") &&
+                error.message.startsWith("invalid kdf.dklen") &&
+                error.argument === "kdf.dklen");
+        });
+
+        const badPbkdf2 = JSON.parse(JSON.stringify(data));
+        badPbkdf2.Crypto.kdf = "pbkdf2";
+        badPbkdf2.Crypto.kdfparams.c = 1;
+        badPbkdf2.Crypto.kdfparams.prf = "hmac-sha1";
+        assert.throws(() => {
+            decryptKeystoreJsonSync(JSON.stringify(badPbkdf2), password);
+        }, (error: any) => {
+            return (isError(error, "INVALID_ARGUMENT") &&
+                error.message.startsWith("invalid kdf.prf") &&
+                error.argument === "kdf.prf");
+        });
+    });
+
 });

--- a/src.ts/wallet/json-keystore.ts
+++ b/src.ts/wallet/json-keystore.ts
@@ -154,7 +154,7 @@ function getDecryptKdfParams<T>(data: any): KdfParams {
             assertArgument(r > 0 && p > 0, "invalid kdf", "kdf", kdf);
 
             const dkLen = spelunk<number>(data, "crypto.kdfparams.dklen:int!");
-            assertArgument(dkLen === 32, "invalid kdf.dklen", "kdf.dflen", dkLen);
+            assertArgument(dkLen === 32, "invalid kdf.dklen", "kdf.dklen", dkLen);
 
             return { name: "scrypt", salt, N, r, p, dkLen: 64 };
 
@@ -164,7 +164,7 @@ function getDecryptKdfParams<T>(data: any): KdfParams {
 
             const prf = spelunk<string>(data, "crypto.kdfparams.prf:string!");
             const algorithm = prf.split("-").pop();
-            assertArgument(algorithm === "sha256" || algorithm === "sha512", "invalid kdf.pdf", "kdf.pdf", prf);
+            assertArgument(algorithm === "sha256" || algorithm === "sha512", "invalid kdf.prf", "kdf.prf", prf);
 
             const count = spelunk<number>(data, "crypto.kdfparams.c:int!");
 
@@ -386,4 +386,3 @@ export async function encryptKeystoreJson(account: KeystoreAccount, password: st
     const key = await scrypt(passwordBytes, kdf.salt, kdf.N, kdf.r, kdf.p, 64, options.progressCallback);
     return _encryptKeystore(getBytes(key), kdf, account, options);
 }
-


### PR DESCRIPTION
Fix two typo-level issues in JSON keystore KDF validation errors:

- report invalid scrypt `dklen` with `kdf.dklen` instead of `kdf.dflen`
- report invalid PBKDF2 `prf` with `kdf.prf` instead of `kdf.pdf`

This does not change successful keystore encryption or decryption behavior. It only makes the `INVALID_ARGUMENT` metadata and error message match the actual invalid fields.
