### PR TITLE
docs: fix HD wallet API docs typos

### DIFF
--- a/src.ts/wallet/hdwallet.ts
+++ b/src.ts/wallet/hdwallet.ts
@@ -329,7 +329,7 @@ export class HDNodeWallet extends BaseWallet {
      *
      *  If the %%extendedKey%% will either have a prefix or ``xpub`` or
      *  ``xpriv``, returning a neutered HD Node ([[HDNodeVoidWallet]])
-     *  or full HD Node ([[HDNodeWallet) respectively.
+     *  or full HD Node ([[HDNodeWallet]]) respectively.
      */
     static fromExtendedKey(extendedKey: string): HDNodeWallet | HDNodeVoidWallet {
         const bytes = toBeArray(decodeBase58(extendedKey)); // @TODO: redact
@@ -404,9 +404,9 @@ export class HDNodeWallet extends BaseWallet {
  *  A **HDNodeVoidWallet** cannot sign, but provides access to
  *  the children nodes of a [[link-bip-32]] HD wallet addresses.
  *
- *  The can be created by using an extended ``xpub`` key to
+ *  It can be created by using an extended ``xpub`` key to
  *  [[HDNodeWallet_fromExtendedKey]] or by 
- *  [nuetering](HDNodeWallet-neuter) a [[HDNodeWallet]].
+ *  [neutering](HDNodeWallet-neuter) a [[HDNodeWallet]].
  */
 export class HDNodeVoidWallet extends VoidSigner {
     /**


### PR DESCRIPTION
## Summary

- Fix a malformed `HDNodeWallet` API doc link in the `fromExtendedKey` JSDoc.
- Fix wording in the `HDNodeVoidWallet` documentation.
- Correct the spelling of `neutering`.

## Motivation

These are small API documentation fixes in the TypeScript source comments used for generated docs. The changes improve the HD wallet docs without changing runtime behavior or generated artifacts.

## Testing

- `npm ci`
- `./node_modules/.bin/tsc --project tsconfig.esm.json --noEmit`
- `./node_modules/.bin/tsc --project tsconfig.commonjs.json --noEmit`
- `git diff --check`