### PR TITLE
fix: use rounding-adjusted value in FixedNumber floor()/ceiling()

### DIFF
--- a/src.ts/_tests/test-utils-fixednumber.ts
+++ b/src.ts/_tests/test-utils-fixednumber.ts
@@ -1,0 +1,43 @@
+import assert from "assert";
+
+import { FixedNumber } from "../index.js";
+
+describe("Tests FixedNumber floor", function() {
+    const tests: Array<{ value: string, expected: string }> = [
+        { value: "0.0", expected: "0.0" },
+        { value: "1.0", expected: "1.0" },
+        { value: "1.5", expected: "1.0" },
+        { value: "1.9", expected: "1.0" },
+        { value: "-1.0", expected: "-1.0" },
+        { value: "-1.5", expected: "-2.0" },
+        { value: "-1.1", expected: "-2.0" },
+        { value: "-0.5", expected: "-1.0" },
+    ];
+
+    for (const { value, expected } of tests) {
+        it(`floors ${ value } to ${ expected }`, function() {
+            const actual = FixedNumber.fromString(value).floor().toString();
+            assert.equal(actual, expected, `floor(${ value })`);
+        });
+    }
+});
+
+describe("Tests FixedNumber ceiling", function() {
+    const tests: Array<{ value: string, expected: string }> = [
+        { value: "0.0", expected: "0.0" },
+        { value: "1.0", expected: "1.0" },
+        { value: "1.5", expected: "2.0" },
+        { value: "1.1", expected: "2.0" },
+        { value: "0.5", expected: "1.0" },
+        { value: "-1.0", expected: "-1.0" },
+        { value: "-1.5", expected: "-1.0" },
+        { value: "-1.9", expected: "-1.0" },
+    ];
+
+    for (const { value, expected } of tests) {
+        it(`ceilings ${ value } to ${ expected }`, function() {
+            const actual = FixedNumber.fromString(value).ceiling().toString();
+            assert.equal(actual, expected, `ceiling(${ value })`);
+        });
+    }
+});

--- a/src.ts/utils/fixednumber.ts
+++ b/src.ts/utils/fixednumber.ts
@@ -484,7 +484,7 @@ export class FixedNumber {
     floor(): FixedNumber {
         let val = this.#val;
         if (this.#val < BN_0) { val -= this.#tens - BN_1; }
-        val = (this.#val / this.#tens) * this.#tens;
+        val = (val / this.#tens) * this.#tens;
         return this.#checkValue(val, "floor");
     }
 
@@ -497,7 +497,7 @@ export class FixedNumber {
     ceiling(): FixedNumber {
         let val = this.#val;
         if (this.#val > BN_0) { val += this.#tens - BN_1; }
-        val = (this.#val / this.#tens) * this.#tens;
+        val = (val / this.#tens) * this.#tens;
         return this.#checkValue(val, "ceiling");
     }
 


### PR DESCRIPTION
## Summary

`FixedNumber.floor()` and `FixedNumber.ceiling()` compute a rounding-bias adjustment into the local `val`, but then truncate using the **unadjusted** field `this.#val` — so the adjustment is silently discarded and BigInt division truncates toward zero instead of toward −∞ (floor) / +∞ (ceiling).

This makes `floor()` wrong for negative non-integers and `ceiling()` wrong for positive non-integers.

## Failing examples (public API)

```js
const { FixedNumber } = require("ethers");

FixedNumber.fromString("-1.5").floor().toString();   // "-1.0"  (expected "-2.0")
FixedNumber.fromString("-1.1").floor().toString();   // "-1.0"  (expected "-2.0")
FixedNumber.fromString("1.5").ceiling().toString();  // "1.0"   (expected "2.0")
FixedNumber.fromString("1.1").ceiling().toString();  // "1.0"   (expected "2.0")
```

Positive `floor()` and negative `ceiling()` happen to be correct because truncation-toward-zero already points the right way there, which is why this slipped through.

## Root cause

```ts
floor(): FixedNumber {
    let val = this.#val;
    if (this.#val < BN_0) { val -= this.#tens - BN_1; }
    val = (this.#val / this.#tens) * this.#tens;   // re-reads this.#val, dropping the adjustment
    return this.#checkValue(val, "floor");
}
```

The adjustment on the second line is only meaningful if the local `val` feeds the truncation on the third line. The sibling `round()` method does exactly this correctly (`value = (value / tens) * tens` using the adjusted local).

## Fix

Truncate the adjusted `val` in both methods:

```ts
val = (val / this.#tens) * this.#tens;
```

This restores the documented contract — `floor()` returns "the largest integer that is less than or equal to" the value, `ceiling()` "the smallest integer that is greater than or equal to".

## Tests

Adds `src.ts/_tests/test-utils-fixednumber.ts` covering `floor()`/`ceiling()` across positive, negative, integer and fractional inputs. With the source reverted to the old behavior, the 6 negative-floor / positive-ceiling cases fail; with the fix all 16 pass. The previously-correct-by-coincidence cases are included as guards against regressions in the other direction.