### PR TITLE
chore(security): add .npmrc with supply-chain security hardening

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+min-release-age=7
+allow-git=none


### PR DESCRIPTION
Blocks `npm` from installing any package version published less than 7 days ago and Refuses to resolve any dependency that comes from a Git source.