### PR TITLE
Use native TextDecoder/TextEncoder in UTF-8 helpers

### DIFF
--- a/src.ts/_tests/test-utils-utf8.ts
+++ b/src.ts/_tests/test-utils-utf8.ts
@@ -135,6 +135,27 @@ describe("Tests UTF-8 bad strings", function() {
         assert.equal(result[1], 0xb0, "data[1]");
         assert.equal(result[2], 0x80, "data[2]");
     });
+
+    // A lone surrogate must behave the same whether the string is short enough
+    // for the pure-JS loop or long enough to reach the native encoder
+    const prefixes = [ { name: "short", prefix: "AB" }, { name: "long", prefix: "A".repeat(256) } ];
+
+    for (const { name, prefix } of prefixes) {
+        it(`correctly fails to get UTF-8 bytes from a mid-string incomplete surrogate: ${ name }`, function() {
+            assert.throws(() => {
+                const result = toUtf8Bytes(prefix + String.fromCharCode(0xd800) + "CD");
+                console.log(result);
+            }, (error: any) => {
+                return (error.message.startsWith("invalid surrogate pair"));
+            });
+        });
+
+        it(`correctly encodes a mid-string lone low surrogate: ${ name }`, function() {
+            const result = toUtf8Bytes(prefix + String.fromCharCode(0xdc00) + "CD");
+            assert.deepEqual(Array.from(result.slice(prefix.length)),
+                [ 0xed, 0xb0, 0x80, 0x43, 0x44 ], "data");
+        });
+    }
 });
 
 describe("Tests UTF-8 edge cases", function() {
@@ -167,6 +188,16 @@ describe("Tests UTF-8 edge cases", function() {
         {
             name: "BOM prefix",
             text: "\ufeffHello"
+        },
+        {
+            // Long enough to use the native encoder; the cases above are
+            // short enough to use the pure-JS loop
+            name: "long ASCII string",
+            text: "The quick brown fox jumps over the lazy dog. ".repeat(8)
+        },
+        {
+            name: "long multi-byte string",
+            text: "AB\u20ac\u{1f600}\ufeff".repeat(64)
         }
     ];
 
@@ -174,16 +205,18 @@ describe("Tests UTF-8 edge cases", function() {
         it(`round-trips: ${ name }`, function() {
             assert.equal(toUtf8String(toUtf8Bytes(text)), text);
         });
-    }
 
-    it("round-trips a large ASCII buffer", function() {
-        const text = "x".repeat(4 * 1024 * 1024);
-        assert.equal(toUtf8String(toUtf8Bytes(text)), text);
-    });
+        // Passing onError bypasses the native decoder, so this pins the
+        // native and pure-JS decoders to the same output
+        it(`decodes identically with and without onError: ${ name }`, function() {
+            const bytes = toUtf8Bytes(text);
+            assert.equal(toUtf8String(bytes), toUtf8String(bytes, Utf8ErrorFuncs.error));
+        });
+    }
 
 });
 
-describe("Tests UTF-8 bad strings", function() {
+describe("Tests UTF-8 code points", function() {
 
     const tests: Array<TestCaseCodePoints> = [
         {

--- a/src.ts/_tests/test-utils-utf8.ts
+++ b/src.ts/_tests/test-utils-utf8.ts
@@ -127,6 +127,60 @@ describe("Tests UTF-8 bad strings", function() {
             return (error.message.startsWith("invalid surrogate pair"));
         });
     });
+
+    it("correctly encodes a lone low surrogate", function() {
+        const result = toUtf8Bytes(String.fromCharCode(0xdc00));
+        assert.equal(result.length, 3, "data.length");
+        assert.equal(result[0], 0xed, "data[0]");
+        assert.equal(result[1], 0xb0, "data[1]");
+        assert.equal(result[2], 0x80, "data[2]");
+    });
+});
+
+describe("Tests UTF-8 edge cases", function() {
+
+    const tests = [
+        {
+            name: "empty string",
+            text: ""
+        },
+        {
+            name: "NUL and control characters",
+            text: "\u0000\u0001\u001f\u007f"
+        },
+        {
+            name: "Euro symbol",
+            text: "AB\u20acC"
+        },
+        {
+            name: "astral pair",
+            text: "A\u{1f600}B"
+        },
+        {
+            name: "maximum code point",
+            text: "\u{10ffff}"
+        },
+        {
+            name: "noncharacters",
+            text: "\ufffe\uffff"
+        },
+        {
+            name: "BOM prefix",
+            text: "\ufeffHello"
+        }
+    ];
+
+    for (const { name, text } of tests) {
+        it(`round-trips: ${ name }`, function() {
+            assert.equal(toUtf8String(toUtf8Bytes(text)), text);
+        });
+    }
+
+    it("round-trips a large ASCII buffer", function() {
+        const text = "x".repeat(4 * 1024 * 1024);
+        assert.equal(toUtf8String(toUtf8Bytes(text)), text);
+    });
+
 });
 
 describe("Tests UTF-8 bad strings", function() {

--- a/src.ts/utils/utf8.ts
+++ b/src.ts/utils/utf8.ts
@@ -241,38 +241,50 @@ function getUtf8CodePoints(_bytes: BytesLike, onError?: Utf8ErrorFunc): Array<nu
 
 // http://stackoverflow.com/questions/18729405/how-to-convert-utf8-string-to-byte-array
 
-let _utf8Decoder: null | InstanceType<typeof TextDecoder> = null;
-let _utf8Encoder: null | InstanceType<typeof TextEncoder> = null;
+// Below this length the fixed per-call cost of TextEncoder.encode exceeds
+// the loop in toUtf8Bytes; the measured crossover is ~64 code units.
+const nativeEncodeThreshold = 128;
+
+// undefined means "not probed yet"; null means "probed, unusable"
+let _utf8Decoder: undefined | null | InstanceType<typeof TextDecoder> = undefined;
+let _utf8Encoder: undefined | null | InstanceType<typeof TextEncoder> = undefined;
 
 function getUtf8Decoder(): null | InstanceType<typeof TextDecoder> {
-    if (_utf8Decoder == null && typeof TextDecoder !== "undefined") {
+    if (_utf8Decoder === undefined && typeof TextDecoder !== "undefined") {
+        _utf8Decoder = null;
         try {
             const decoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
-            // Decoding a lone continuation byte throws only when fatal is
-            // enforced; engines that ignore it get the pure-JS path.
-            let fatal = false;
+
+            // A lone continuation byte throws only where fatal is honoured and
+            // a BOM survives only where ignoreBOM is; an engine that accepts
+            // the options but implements neither would silently change the
+            // behaviour of toUtf8String, so it gets the pure-JS path.
             try {
                 decoder.decode(new Uint8Array([ 0x80 ]));
             } catch (error) {
-                fatal = true;
+                if (decoder.decode(new Uint8Array([ 0xef, 0xbb, 0xbf ])) === "\ufeff") {
+                    _utf8Decoder = decoder;
+                }
             }
-            if (fatal) { _utf8Decoder = decoder; }
         } catch (error) { }
     }
-    return _utf8Decoder;
+    return _utf8Decoder || null;
 }
 
 function getUtf8Encoder(): null | InstanceType<typeof TextEncoder> {
-    if (_utf8Encoder == null && typeof TextEncoder !== "undefined") {
+    if (_utf8Encoder === undefined && typeof TextEncoder !== "undefined") {
+        _utf8Encoder = null;
         try {
             _utf8Encoder = new TextEncoder();
         } catch (error) { }
     }
-    return _utf8Encoder;
+    return _utf8Encoder || null;
 }
 
-// TextEncoder silently replaces lone surrogates with U+FFFD in some engines
-// (e.g. node) instead of throwing, so they must be detected before using it.
+// TextEncoder takes a USVString, so it replaces lone surrogates with U+FFFD
+// rather than throwing; detect them first and use the pure-JS path, which
+// preserves the existing behaviour (a lone high surrogate throws, while a
+// lone low surrogate is encoded).
 function hasLoneSurrogates(str: string): boolean {
     for (let i = 0; i < str.length; i++) {
         const c = str.charCodeAt(i);
@@ -291,9 +303,6 @@ function hasLoneSurrogates(str: string): boolean {
  *  Returns the UTF-8 byte representation of %%str%%.
  *
  *  If %%form%% is specified, the string is normalized.
- *
- *  A native ``TextEncoder`` is used when available, falling back to
- *  the pure-JS implementation.
  */
 export function toUtf8Bytes(str: string, form?: UnicodeNormalizationForm): Uint8Array {
     assertArgument(typeof(str) === "string", "invalid string value", "str", str);
@@ -303,11 +312,9 @@ export function toUtf8Bytes(str: string, form?: UnicodeNormalizationForm): Uint8
         str = str.normalize(form);
     }
 
-    const encoder = getUtf8Encoder();
-    if (encoder != null && !hasLoneSurrogates(str)) {
-        try {
-            return encoder.encode(str);
-        } catch (error) { }
+    if (str.length >= nativeEncodeThreshold) {
+        const encoder = getUtf8Encoder();
+        if (encoder != null && !hasLoneSurrogates(str)) { return encoder.encode(str); }
     }
 
     let result: Array<number> = [];
@@ -366,27 +373,22 @@ function _toUtf8String(codePoints: Array<number>): string {
  *  errors allowing recovery using the [[Utf8ErrorFunc]] API.
  *  (default: [error](Utf8ErrorFuncs))
  *
- *  A native ``TextDecoder`` is used when available, falling back to
- *  the pure-JS implementation.
+ *  When no %%onError%% is provided a native ``TextDecoder`` is used where
+ *  available; providing %%onError%% always uses the slower pure-JS decoder.
  */
 export function toUtf8String(bytes: BytesLike, onError?: Utf8ErrorFunc): string {
+    const data = getBytes(bytes, "bytes");
+
     if (onError == null) {
         const decoder = getUtf8Decoder();
         if (decoder != null) {
             try {
-                const data = getBytes(bytes, "bytes");
-                const result = decoder.decode(data);
-                // The pure-JS implementation keeps a leading BOM; engines
-                // that ignore ignoreBOM strip it, so restore it if missing.
-                if (data.length >= 3 && data[0] === 0xef && data[1] === 0xbb && data[2] === 0xbf &&
-                    result.charCodeAt(0) !== 0xfeff) {
-                    return "\ufeff" + result;
-                }
-                return result;
+                return decoder.decode(data);
             } catch (error) { }
         }
     }
-    return _toUtf8String(getUtf8CodePoints(bytes, onError));
+
+    return _toUtf8String(getUtf8CodePoints(data, onError));
 }
 
 /**

--- a/src.ts/utils/utf8.ts
+++ b/src.ts/utils/utf8.ts
@@ -241,10 +241,59 @@ function getUtf8CodePoints(_bytes: BytesLike, onError?: Utf8ErrorFunc): Array<nu
 
 // http://stackoverflow.com/questions/18729405/how-to-convert-utf8-string-to-byte-array
 
+let _utf8Decoder: null | InstanceType<typeof TextDecoder> = null;
+let _utf8Encoder: null | InstanceType<typeof TextEncoder> = null;
+
+function getUtf8Decoder(): null | InstanceType<typeof TextDecoder> {
+    if (_utf8Decoder == null && typeof TextDecoder !== "undefined") {
+        try {
+            const decoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
+            // Decoding a lone continuation byte throws only when fatal is
+            // enforced; engines that ignore it get the pure-JS path.
+            let fatal = false;
+            try {
+                decoder.decode(new Uint8Array([ 0x80 ]));
+            } catch (error) {
+                fatal = true;
+            }
+            if (fatal) { _utf8Decoder = decoder; }
+        } catch (error) { }
+    }
+    return _utf8Decoder;
+}
+
+function getUtf8Encoder(): null | InstanceType<typeof TextEncoder> {
+    if (_utf8Encoder == null && typeof TextEncoder !== "undefined") {
+        try {
+            _utf8Encoder = new TextEncoder();
+        } catch (error) { }
+    }
+    return _utf8Encoder;
+}
+
+// TextEncoder silently replaces lone surrogates with U+FFFD in some engines
+// (e.g. node) instead of throwing, so they must be detected before using it.
+function hasLoneSurrogates(str: string): boolean {
+    for (let i = 0; i < str.length; i++) {
+        const c = str.charCodeAt(i);
+        if (c >= 0xd800 && c <= 0xdbff) {
+            const c2 = (i + 1 < str.length) ? str.charCodeAt(i + 1): 0;
+            if (c2 < 0xdc00 || c2 > 0xdfff) { return true; }
+            i++;
+        } else if (c >= 0xdc00 && c <= 0xdfff) {
+            return true;
+        }
+    }
+    return false;
+}
+
 /**
  *  Returns the UTF-8 byte representation of %%str%%.
  *
  *  If %%form%% is specified, the string is normalized.
+ *
+ *  A native ``TextEncoder`` is used when available, falling back to
+ *  the pure-JS implementation.
  */
 export function toUtf8Bytes(str: string, form?: UnicodeNormalizationForm): Uint8Array {
     assertArgument(typeof(str) === "string", "invalid string value", "str", str);
@@ -252,6 +301,13 @@ export function toUtf8Bytes(str: string, form?: UnicodeNormalizationForm): Uint8
     if (form != null) {
         assertNormalize(form);
         str = str.normalize(form);
+    }
+
+    const encoder = getUtf8Encoder();
+    if (encoder != null && !hasLoneSurrogates(str)) {
+        try {
+            return encoder.encode(str);
+        } catch (error) { }
     }
 
     let result: Array<number> = [];
@@ -309,8 +365,27 @@ function _toUtf8String(codePoints: Array<number>): string {
  *  When %%onError%% function is specified, it is called on UTF-8
  *  errors allowing recovery using the [[Utf8ErrorFunc]] API.
  *  (default: [error](Utf8ErrorFuncs))
+ *
+ *  A native ``TextDecoder`` is used when available, falling back to
+ *  the pure-JS implementation.
  */
 export function toUtf8String(bytes: BytesLike, onError?: Utf8ErrorFunc): string {
+    if (onError == null) {
+        const decoder = getUtf8Decoder();
+        if (decoder != null) {
+            try {
+                const data = getBytes(bytes, "bytes");
+                const result = decoder.decode(data);
+                // The pure-JS implementation keeps a leading BOM; engines
+                // that ignore ignoreBOM strip it, so restore it if missing.
+                if (data.length >= 3 && data[0] === 0xef && data[1] === 0xbb && data[2] === 0xbf &&
+                    result.charCodeAt(0) !== 0xfeff) {
+                    return "\ufeff" + result;
+                }
+                return result;
+            } catch (error) { }
+        }
+    }
     return _toUtf8String(getUtf8CodePoints(bytes, onError));
 }
 


### PR DESCRIPTION
Closes #5168. `FetchResponse.bodyText` runs every JSON-RPC response through `toUtf8String`, which builds an array element per byte and a one-character string per code point before `JSON.parse` runs. An 18.7MB `trace_block` response burns 783MB of heap doing that.

## Change

- `toUtf8String` decodes with a native `TextDecoder` when one is available and the caller passed no `onError`. If that throws, it falls back to the pure-JS FSM, so the error you get back (message, offset, reason) is unchanged. `onError` callers never touch the native path.
- `toUtf8Bytes` uses `TextEncoder` for strings of 128 code units or more. Below that the existing loop is faster than the call overhead. `TextEncoder` takes a USVString, so it turns lone surrogates into U+FFFD where ethers throws or emits CESU-8, and a pre-scan sends those strings back to the loop.
- A decoder is only used once it proves it honors `fatal` and `ignoreBOM`. Some polyfills accept both options and implement neither. Failed probes are cached too, so a bad polyfill no longer costs a `TextDecoder` construction on every call.
- Tests compare the native and pure-JS decoders against each other (passing `onError` picks the pure-JS one), use inputs long enough to reach the native encoder, and cover lone surrogates mid-string on both paths.

## Risk

Correctness now leans on the engine's decoder. The probe catches implementations that take `fatal` and `ignoreBOM` without honoring them, but one that honors both and still diverges somewhere else would slip through. I didn't find any that do.

## Evidence

Differential against the pre-PR `toUtf8String` and `toUtf8Bytes`, comparing the return value and the thrown message, offset and reason. Covered every 1-, 2- and 3-byte sequence, structured 4-byte coverage, every code unit from 0x0000 to 0xffff at both short and long lengths, and every surrogate pair. Just over 17M cases, nothing diverged.

Offline suites:

```
test-utils-*, test-hash*, test-abi, test-address, test-rlp, test-crypto, test-typed-data
  47963 passing (12s)
test-wallet*, test-wordlists, test-transaction, test-account
  66130 passing (3m)
test-utils-utf8, esm and commonjs
  53 passing
```

Mutation run over the utf8 suite. 10 mutants, 8 died:

```
lone-surrogate scan cut to index 0     51 passing    2 failing
low-surrogate arm removed              52 passing    1 failing
high-surrogate arm removed             52 passing    1 failing
native decode strips a leading BOM     51 passing    2 failing
probe bypassed, non-fatal decoder      42 passing   11 failing
native encode, surrogate guard off     46 passing    7 failing
pure-JS ASCII encode corrupted         46 passing    7 failing
pure-JS astral decode corrupted        50 passing    3 failing
ignoreBOM dropped                      53 passing
full revert to pre-PR                  53 passing
```

The bottom two are meant to survive. Dropping `ignoreBOM` makes the probe reject that decoder and fall back, and a straight revert behaves identically, it just eats the memory again.

The workload from the issue, 3 x 18.7MB under `node --max-old-space-size=256`:

```
pre-PR        FATAL ERROR: Reached heap limit Allocation failed
this branch   18.5ms, peak heapUsed 57MB
```

A single 18.7MB decode on its own goes from 861.7ms and +783.3MB heapUsed to 3.7ms and +17.9MB.

`toUtf8Bytes` either side of the 128 gate, ns/op:

```
         pre-PR      now
 1B        69.3     75.1
 7B        89.4     89.7
256B     1497.2    888.3
4KB     19805.1  11801.1
```

100,000 `toUtf8String` calls under a polyfill that rejects `{fatal:true}` now cost one `TextDecoder` construction and 81.4ms. Baseline with no `TextDecoder` at all is 77.0ms, so the probe caching lands where it should.

`npm run build && npm run build-commonjs` both clean.
