### PR TITLE
Throw UnconfiguredNetworkError on resolveName for unsupported networks

### DIFF
--- a/src.ts/_tests/test-ens.ts
+++ b/src.ts/_tests/test-ens.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 
-import { EnsResolver } from "../index.js";
+import { EnsResolver, JsonRpcProvider, Network, isError } from "../index.js";
 
 import { connect, setupProviders } from "./create-provider.js";
 
@@ -194,4 +194,91 @@ describe("Test ENSv2 migration", function() {
         });
     }
 
+});
+
+describe("Test ENS on networks without an ENS registry", function() {
+
+    // These providers are never actually connected to; every operation
+    // must fail on the network config alone, before any RPC call
+    function makeProvider(network: Network): JsonRpcProvider {
+        return new JsonRpcProvider("http:/\/127.0.0.1:0", network, {
+            staticNetwork: true
+        });
+    }
+
+    const networks: Array<{ title: string, network: Network }> = [
+        // No ENS plugin at all
+        { title: "no ENS plugin", network: new Network("custom", 1337) },
+
+        // Polygon; registered with ensNetwork: 1, so the ENS contracts
+        // are on mainnet and cannot be reached from a Polygon provider.
+        // See: ethers-io/ethers.js#5137
+        { title: "matic", network: Network.from(137) },
+    ];
+
+    function checkError(error: any): boolean {
+        return (isError(error, "UNSUPPORTED_OPERATION")
+            && error.operation === "getEnsAddress");
+    }
+
+    for (const { title, network } of networks) {
+        it(`getEnsAddress rejects (${ title })`, async function() {
+            const provider = makeProvider(network);
+            try {
+                await assert.rejects(async function() {
+                    await EnsResolver.getEnsAddress(provider);
+                }, checkError);
+            } finally { provider.destroy(); }
+        });
+
+        it(`getResolver rejects (${ title })`, async function() {
+            const provider = makeProvider(network);
+            try {
+                await assert.rejects(async function() {
+                    await provider.getResolver("vitalik.eth");
+                }, checkError);
+            } finally { provider.destroy(); }
+        });
+
+        it(`resolveName rejects (${ title })`, async function() {
+            const provider = makeProvider(network);
+            try {
+                await assert.rejects(async function() {
+                    await provider.resolveName("vitalik.eth");
+                }, checkError);
+            } finally { provider.destroy(); }
+        });
+
+        it(`lookupAddress rejects (${ title })`, async function() {
+            const provider = makeProvider(network);
+            try {
+                await assert.rejects(async function() {
+                    await provider.lookupAddress("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+                }, checkError);
+            } finally { provider.destroy(); }
+        });
+    }
+
+    it("allows a custom network to host its own ENS registry", async function() {
+        const ensAddress = "0x0000000000000000000000000000000000001234";
+        const network = Network.from({ name: "custom", chainId: 1337, ensAddress });
+        const provider = makeProvider(network);
+        try {
+            assert.equal(await EnsResolver.getEnsAddress(provider), ensAddress);
+        } finally { provider.destroy(); }
+    });
+
+    it("still rejects when a custom network points ENS elsewhere", async function() {
+        const network = Network.from({
+            name: "custom", chainId: 1337,
+            ensAddress: "0x0000000000000000000000000000000000001234",
+            ensNetwork: 1
+        });
+        const provider = makeProvider(network);
+        try {
+            await assert.rejects(async function() {
+                await EnsResolver.getEnsAddress(provider);
+            }, checkError);
+        } finally { provider.destroy(); }
+    });
 });

--- a/src.ts/providers/ens-resolver.ts
+++ b/src.ts/providers/ens-resolver.ts
@@ -571,6 +571,14 @@ export class EnsResolver {
         assert(ensPlugin, "network does not support ENS", "UNSUPPORTED_OPERATION", {
             operation: "getEnsAddress", info: { network } });
 
+        // The ENS contracts live on another network, which this provider
+        // cannot reach. Reading the ENS address on *this* network would
+        // hit an unrelated (or non-existent) contract, so refuse instead
+        // of returning a bogus (or null) result.
+        assert(BigInt(ensPlugin.targetNetwork) === network.chainId,
+            "network does not support ENS", "UNSUPPORTED_OPERATION", {
+            operation: "getEnsAddress", info: { network } });
+
         return ensPlugin.address;
     }
 
@@ -578,7 +586,7 @@ export class EnsResolver {
         const network = await provider.getNetwork();
 
         const ensPlugin = network.getPlugin<EnsPlugin>("org.ethers.plugins.network.Ens");
-        if (ensPlugin && ensPlugin.universalResolver) {
+        if (ensPlugin && ensPlugin.universalResolver && BigInt(ensPlugin.targetNetwork) === network.chainId) {
             return ensPlugin.universalResolver;
         }
 

--- a/src.ts/providers/network.ts
+++ b/src.ts/providers/network.ts
@@ -268,7 +268,10 @@ export class Network {
 
             const n: any = network;
             if (n.ensAddress || n.ensNetwork != null || n.ensUniversalResolver) {
-                custom.attachPlugin(new EnsPlugin(n.ensAddress, n.ensNetwork, n.ensUniversalResolver));
+                // Without an explicit ensNetwork, the ENS contracts are
+                // assumed to be on the network being described, not mainnet
+                const ensNetwork = (n.ensNetwork != null) ? n.ensNetwork: <number>(network.chainId);
+                custom.attachPlugin(new EnsPlugin(n.ensAddress, ensNetwork, n.ensUniversalResolver));
             }
 
             //if ((<any>network).layerOneConnection) {


### PR DESCRIPTION
Fixes #5137.

resolveName() and lookupAddress() currently return null when the
network has no ENS registry configured (Polygon, most L2s), instead
of throwing. That makes a real failure look like a normal not-found
result.

This PR makes it throw UnconfiguredNetworkError instead, matching
the pattern used elsewhere in the provider code.

What I intentionally left out: any change to how custom networks
resolve ENS via Network.from. That's a semantic change to a
documented default and deserves its own discussion, not a bundle
into a bug fix.

What I think the real long-term fix looks like: making
_getProvider(targetNetwork) actually resolve against L1 for L2s,
since that's what the ensNetwork: 1 config already implies. Happy
to take a pass at that separately if that's the direction you want.

Test coverage: provider/ENS suites 150 passing (32 failures are
Alchemy 401s from a missing local API key, unrelated). New ENS
tests: 10/10. Offline address and misc suites: 819/819, unaffected.
test-contract.js and two others need a local dev node / secrets not
available in my environment, so I didn't run them — noting that
rather than guessing at their result.