### PR TITLE
Fix Transaction.from(tx.toJSON()) roundtrip losing authorizationList and blob fields

### DIFF
--- a/src.ts/_tests/test-providers-jsonrpc.ts
+++ b/src.ts/_tests/test-providers-jsonrpc.ts
@@ -168,11 +168,13 @@ describe("Ensure Catchable Errors", function() {
                 case "eth_getTransactionByHash": {
                     count++;
 
-                    // The fully valid tx response
+                    // The fully valid tx response; a node returns the
+                    // signature as loose r/s/v, so drop the nested copies
+                    // toJSON includes or there is nothing to recover from
                     const result = Object.assign({ },
                         txObj.toJSON(),
                         txObj.signature!.toJSON(),
-                        { hash: txObj.hash, from: wallet.address, sig: null });
+                        { hash: txObj.hash, from: wallet.address, sig: null, signature: null });
 
                     // First time; fail with a missing v!
                     if (count < 2) { delete result.v; }

--- a/src.ts/_tests/test-transaction.ts
+++ b/src.ts/_tests/test-transaction.ts
@@ -457,3 +457,121 @@ describe("Tests Transaction Parameters", function() {
 
     }
 });
+
+describe("Tests Transaction JSON Round-Trip", function() {
+    const tests = loadTests<TestCaseTransaction>("transactions");
+
+    // Each test walks the entire testcase set, so the default 2s is tight
+    this.timeout(60000);
+
+    // Real, on-chain transactions. The shared testcases contain no EIP-7702
+    // transaction at all, and these additionally pin the round-trip against
+    // bytes a node actually produced.
+
+    // https://etherscan.io/tx/0x57482e4115a77b3250c0bb79f56e86f1fdd15ad188f562984312794c5810bb23
+    const mainnetEip7702 = "0x04f8c901808477359400847c6ee93683010fc5947ec7bf1d9ac17969bc44e1aef9e803f7e310ded38080c0f85cf85a019463c0c19a282a1b52b07dd5a65b58948a07dae32b0101a0aeec31d7cb51ebfbf70564e17d75f52c9aeeceb423df65289dd911a1447b7b92a06aa24b1501b99ce094238aae9addf76827d560f916092ad5e099b3eeaaab4ae401a07a5e3a20811f8c5d784d45bb84069353df5cedc1d8ac772ca9c99afb5972818ba044fa7428939114b3fda67e54af5d8cd781c1a8278f43f69c4f5dc54fac42fb1c";
+
+    // https://etherscan.io/tx/0x8bfd1c44ac1795fcaa7cccf717975f99de6ead5a9f9c73ae6040348cb4b2f1be
+    const mainnetEip4844 = "0x03f904a40183015976843b9aca0085027a69ce6483061a8094bd0d173eeb87d57a09521c24388a12789f33ba9680b901a4917cf8ac0000000000000000000000000000000000000000000000000000000000015977000000000000000000000000000000000000000000000000000000000001a3f100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001d643b80000000000000000000000000000000000000000000000000000000001d645a10140c3b797253331a501a7b41c8aff79c6ac17b31c5b21299e643a1552425844000000000000000000000000000000000000000000000000000000000000000d000000000000000000000000daa526086787d9debe1d7f3ffdb1fe50cf8687f40000000000000000000000000000000000000000000000000000000001884628000000000000000000000000000000000000000000000000000000006a76ba7b000000000000000000000000000000000000000000000000000000000001a3e60000000000000000000000000000000000000000000000000000000003c33b678a68eb1f5a927f70bf0ecae1178262936789b6e8c763697a5e6ab3ba09490083f90223f8dd94bd0d173eeb87d57a09521c24388a12789f33ba96f8c6a00000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000001a0000000000000000000000000000000000000000000000000000000000000000aa0b53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103a0360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbca0d89986db8de948a4d23da9fd6fa217aa05166251f666d5d2bb345eefd323354bf9014194df8755334ce7a73ccf6b581c02ea649ae3e864b3f90129a00000000000000000000000000000000000000000000000000000000000000006a00000000000000000000000000000000000000000000000000000000000000007a00000000000000000000000000000000000000000000000000000000000000009a0000000000000000000000000000000000000000000000000000000000000000aa0b53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103a0360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbca0a66cc928b5edb82af9bd49922954155ab7b0942694bea4ce44661d9a87381ffea0a66cc928b5edb82af9bd49922954155ab7b0942694bea4ce44661d9a87381fffa0f652222313e28459528d920b65115c16c04f3efc82aaedc97be59f3f377db12f84020482aef863a001f2c94526a287a157ca575cba4fb2b8feef24693a1912435a973252d9833f3ca001987a408e5718d9d3a438f170b4fdb3b8761e05a762e5e8422b2963a0279ee9a001f0432958fcd89f6b84f3082c29460505eb8f59381098a19150501e5f762d2580a0d11595017fbcc0781d6c3856cc4e93419531d76f614a2ca258c1a73e9f603bffa041579bad5aa8c2f108c64bb38c6ad1fb8f98a9e1db30512c3b846057671c5145";
+
+    // A toJSON result must survive an actual JSON encode; i.e. no bigints
+    function roundTrip(tx: Transaction): Transaction {
+        return Transaction.from(JSON.parse(JSON.stringify(tx.toJSON())));
+    }
+
+    // A byte-identical serialized re-encoding implies a matching hash and
+    // recovered sender, so those are only asserted on the mainnet cases
+    // below, where they can be pinned against real on-chain values.
+    function assertSignedRoundTrip(raw: string, name: string): Transaction {
+        const tx = Transaction.from(raw);
+        const copy = roundTrip(tx);
+
+        assert.equal(copy.type, tx.type, `${ name }: type`);
+        assert.equal(copy.unsignedSerialized, tx.unsignedSerialized, `${ name }: unsignedSerialized`);
+        assert.equal(copy.serialized, raw, `${ name }: serialized`);
+
+        return copy;
+    }
+
+    it("round-trips signed legacy transactions", function() {
+        for (const test of tests) {
+            assertSignedRoundTrip(test.signedLegacy, `legacy ${ test.name }`);
+        }
+    });
+
+    it("round-trips signed EIP-155 transactions", function() {
+        for (const test of tests) {
+            if (!test.unsignedEip155) { continue; }
+            assertSignedRoundTrip(test.signedEip155, `eip-155 ${ test.name }`);
+        }
+    });
+
+    it("round-trips signed Berlin transactions", function() {
+        for (const test of tests) {
+            assertSignedRoundTrip(test.signedBerlin, `berlin ${ test.name }`);
+        }
+    });
+
+    it("round-trips signed London transactions", function() {
+        for (const test of tests) {
+            assertSignedRoundTrip(test.signedLondon, `london ${ test.name }`);
+        }
+    });
+
+    it("round-trips signed Cancun transactions", function() {
+        for (const test of tests) {
+            if (!test.signedCancun) { continue; }
+            const copy = assertSignedRoundTrip(test.signedCancun, `cancun ${ test.name }`);
+            const tx = Transaction.from(test.signedCancun);
+            assert.equal(copy.maxFeePerBlobGas, tx.maxFeePerBlobGas, `cancun ${ test.name }: maxFeePerBlobGas`);
+            assert.deepEqual(copy.blobVersionedHashes, tx.blobVersionedHashes, `cancun ${ test.name }: blobVersionedHashes`);
+        }
+    });
+
+    it("round-trips unsigned transactions", function() {
+        for (const test of tests) {
+            for (const raw of [ test.unsignedLegacy, test.unsignedBerlin, test.unsignedLondon, test.unsignedCancun ]) {
+                if (!raw) { continue; }
+                const tx = Transaction.from(raw);
+                const copy = roundTrip(tx);
+                assert.equal(copy.signature, null, `${ test.name }: signature`);
+                assert.equal(copy.unsignedSerialized, raw, `${ test.name }: unsignedSerialized`);
+                assert.equal(copy.unsignedHash, tx.unsignedHash, `${ test.name }: unsignedHash`);
+            }
+        }
+    });
+
+    it("round-trips an EIP-4844 transaction with BLObs (mainnet)", function() {
+        const tx = Transaction.from(mainnetEip4844);
+        const copy = assertSignedRoundTrip(mainnetEip4844, "eip-4844");
+
+        assert.equal(copy.hash, "0x8bfd1c44ac1795fcaa7cccf717975f99de6ead5a9f9c73ae6040348cb4b2f1be", "hash");
+        assert.equal(copy.from, "0xDaa526086787d9DEbE1D7F3FFdb1fE50cf8687F4", "from");
+
+        assert.equal(copy.maxFeePerBlobGas, tx.maxFeePerBlobGas, "maxFeePerBlobGas");
+        assert.equal((copy.blobVersionedHashes || [ ]).length, 3, "blobVersionedHashes.length");
+        assert.deepEqual(copy.blobVersionedHashes, tx.blobVersionedHashes, "blobVersionedHashes");
+    });
+
+    it("round-trips an EIP-7702 transaction with authorizations (mainnet)", function() {
+        const tx = Transaction.from(mainnetEip7702);
+        const copy = assertSignedRoundTrip(mainnetEip7702, "eip-7702");
+
+        assert.equal(copy.hash, "0x57482e4115a77b3250c0bb79f56e86f1fdd15ad188f562984312794c5810bb23", "hash");
+        assert.equal(copy.from, "0x7eC7BF1d9ac17969bC44E1AEF9E803f7E310deD3", "from");
+
+        const auths = copy.authorizationList;
+        const expected = tx.authorizationList;
+        assert.ok(auths != null && expected != null, "authorizationList:!null");
+        assert.equal(auths.length, 1, "authorizationList.length");
+
+        for (let i = 0; i < expected.length; i++) {
+            assert.equal(auths[i].address, expected[i].address, `auth[${ i }].address`);
+            assert.equal(auths[i].chainId, expected[i].chainId, `auth[${ i }].chainId`);
+            assert.equal(auths[i].nonce, expected[i].nonce, `auth[${ i }].nonce`);
+            assert.equal(auths[i].signature.r, expected[i].signature.r, `auth[${ i }].signature.r`);
+            assert.equal(auths[i].signature.s, expected[i].signature.s, `auth[${ i }].signature.s`);
+            assert.equal(auths[i].signature.yParity, expected[i].signature.yParity, `auth[${ i }].signature.yParity`);
+        }
+    });
+});

--- a/src.ts/transaction/transaction.ts
+++ b/src.ts/transaction/transaction.ts
@@ -1420,12 +1420,20 @@ export class Transaction implements TransactionLike<string> {
 
     /**
      *  Return a JSON-friendly object.
+     *
+     *  The result may be passed back to [[from]] to recreate this
+     *  Transaction; the [[blobs]] and [[kzg]] are not included, so a
+     *  BLOb sidecar cannot survive the round-trip.
      */
     toJSON(): any {
         const s = (v: null | bigint) => {
             if (v == null) { return null; }
             return v.toString();
         };
+
+        const sig = this.signature ? this.signature.toJSON(): null;
+
+        const auths = this.authorizationList;
 
         return {
             type: this.type,
@@ -1439,8 +1447,22 @@ export class Transaction implements TransactionLike<string> {
             maxFeePerGas: s(this.maxFeePerGas),
             value: s(this.value),
             chainId: s(this.chainId),
-            sig: this.signature ? this.signature.toJSON(): null,
-            accessList: this.accessList
+
+            // The "sig" key is what v6 has always emitted; "signature" is
+            // the name from TransactionLike, which is what from() reads
+            sig, signature: sig,
+
+            accessList: this.accessList,
+
+            maxFeePerBlobGas: s(this.maxFeePerBlobGas),
+            blobVersionedHashes: this.blobVersionedHashes,
+
+            authorizationList: (auths == null) ? null: auths.map((a) => ({
+                address: a.address,
+                nonce: s(a.nonce),
+                chainId: s(a.chainId),
+                signature: a.signature.toJSON()
+            }))
         };
     }
 


### PR DESCRIPTION
Fixes #5172.

toJSON() followed by Transaction.from() was dropping authorizationList on type 4 transactions and blobVersionedHashes/maxFeePerBlobGas on type 3, causing unsignedHash mismatches on roundtrip. Signed transactions also failed to roundtrip since the signature field wasn't read back from the parsed JSON.

Full offline test suite: 114095 passing across all 20 files. Network-dependent suites (contract, ens, providers-avatar/ccip/data/errors/send/wildcard) weren't run locally due to missing API keys, but are covered by CI.

One existing test needed updating: test-providers-jsonrpc.ts fakes an RPC response by spreading a Transaction's toJSON() and signature.toJSON() together, then deletes v to test the missing-v recovery path. Since this fix makes toJSON() emit signature, that fake response now takes the signature-present branch in formatTransactionResponse instead of hitting the sabotage. I added signature: null alongside the existing sig: null to keep exercising the same recovery path. Confirmed the test fails on unmodified transaction.ts and passes with this fix, so the change reflects the real behavior difference rather than papering over something.

Both sig and signature are emitted in the JSON output — duplicated, but non-breaking. Renaming sig to signature would break any consumer currently reading .sig, and I didn't want to make that semver call in a bug fix PR. Happy to go that direction if you'd prefer.

blobWrapperVersion is intentionally left out since blob sidecars can't round-trip through toJSON in the first place — blobs are 128KB each and aren't serialized. Documented that limit in the doc comment rather than including an inert field.