### PR TITLE
fix: guard CCIP-Read dataSlice against short error.data to prevent BUFFER_OVERRUN

### DIFF
--- a/src.ts/providers/abstract-provider.ts
+++ b/src.ts/providers/abstract-provider.ts
@@ -1031,7 +1031,7 @@ export class AbstractProvider implements Provider {
 
          } catch (error: any) {
              // CCIP Read OffchainLookup
-             if (!this.disableCcipRead && isCallException(error) && error.data && attempt >= 0 && blockTag === "latest" && transaction.to != null && dataSlice(error.data, 0, 4) === "0x556f1830") {
+             if (!this.disableCcipRead && isCallException(error) && error.data && dataLength(error.data) >= 4 && attempt >= 0 && blockTag === "latest" && transaction.to != null && dataSlice(error.data, 0, 4) === "0x556f1830") {
                  const data = error.data;
 
                  const txSender = await resolveAddress(transaction.to, this);


### PR DESCRIPTION
## Problem

When a CCIP-Read enabled contract reverts with empty or short `error.data` (e.g. `0x`), the OffchainLookup check in `#call` crashes with `BUFFER_OVERRUN` instead of propagating the original call error.

This happens because the condition on line 1034 checks `error.data` for truthiness — `"0x"` is truthy — then immediately passes it to `dataSlice(error.data, 0, 4)`, which throws when the data is shorter than 4 bytes.

Affects any ENS offchain name lookup (e.g. `.xyz` domains via CCIP resolvers) where the resolver reverts without data.

## Root Cause

```typescript
// before
if (... && error.data && dataSlice(error.data, 0, 4) === "0x556f1830") {
//          ^^^^^^^^^^
//          "0x" is truthy, but dataSlice("0x", 0, 4) → BUFFER_OVERRUN
```

## Fix

Add a `dataLength` guard before `dataSlice`. `dataLength` is already imported and used elsewhere in the file (line 1711).

```typescript
// after
if (... && error.data && dataLength(error.data) >= 4 && dataSlice(error.data, 0, 4) === "0x556f1830") {
```

## Reproduction

```typescript
import { getDefaultProvider, EnsResolver } from 'ethers';

const provider = getDefaultProvider();
const resolver = new EnsResolver(provider, '0xf142b308cf687d4358410a4cb885513b30a42025', 'mnhsu.xyz');
const address = await resolver.getAddress();
// → BUFFER_OVERRUN instead of null
```

Closes #4982