### PR TITLE
fix: handle rejected eth_subscribe in SocketSubscriber to prevent uncatchable unhandled rejection

### DIFF
--- a/src.ts/_tests/test-providers-socket-subscribe.ts
+++ b/src.ts/_tests/test-providers-socket-subscribe.ts
@@ -1,0 +1,150 @@
+import assert from "assert";
+
+import { makeError } from "../index.js";
+
+import { SocketProvider, SocketBlockSubscriber } from "../providers/provider-socket.js";
+
+import type {
+    JsonRpcPayload, JsonRpcResult, JsonRpcError
+} from "../providers/provider-jsonrpc.js";
+
+class MockSocketProvider extends SocketProvider {
+    _sendResolvers: Map<number, { resolve: (v: any) => void, reject: (e: any) => void }> = new Map();
+    _lastPayload: JsonRpcPayload | null = null;
+
+    constructor() {
+        super("mainnet", { staticNetwork: true });
+    }
+
+    async _write(message: string): Promise<void> {
+        // no-op
+    }
+
+    init(): void {
+        this._start();
+    }
+
+    override async _send(payload: JsonRpcPayload | Array<JsonRpcPayload>): Promise<Array<JsonRpcResult | JsonRpcError>> {
+        if (Array.isArray(payload)) { throw new Error("unexpected batch"); }
+        this._lastPayload = payload;
+
+        return new Promise((resolve, reject) => {
+            this._sendResolvers.set(payload.id, {
+                resolve: (result: any) => resolve([{ id: payload.id, result }]),
+                reject: (error: any) => reject(error),
+            });
+        });
+    }
+
+    respondTo(id: number, result: any): void {
+        const r = this._sendResolvers.get(id);
+        if (r) { r.resolve(result); this._sendResolvers.delete(id); }
+    }
+
+    rejectTo(id: number, error: any): void {
+        const r = this._sendResolvers.get(id);
+        if (r) { r.reject(error); this._sendResolvers.delete(id); }
+    }
+}
+
+describe("SocketSubscriber error handling", function () {
+    let unhandledRejections: Array<any>;
+    let handler: (reason: any) => void;
+
+    beforeEach(function () {
+        unhandledRejections = [];
+        handler = (reason: any) => { unhandledRejections.push(reason); };
+        process.on("unhandledRejection", handler);
+    });
+
+    afterEach(function () {
+        process.removeListener("unhandledRejection", handler);
+        assert.equal(unhandledRejections.length, 0,
+            `unexpected unhandled rejections: ${unhandledRejections.map((r) => r?.message || r)}`);
+    });
+
+    it("should emit error event when eth_subscribe is rejected", async function () {
+        this.timeout(5000);
+
+        const provider = new MockSocketProvider();
+        provider.init();
+
+        const sub = new SocketBlockSubscriber(provider as any);
+
+        const errorReceived = new Promise<any>((resolve) => {
+            provider.on("error", (err: any) => {
+                resolve(err);
+            });
+        });
+
+        sub.start();
+
+        await new Promise((r) => setTimeout(r, 50));
+
+        const payloadId = provider._lastPayload!.id;
+        provider.rejectTo(payloadId, makeError("subscription rejected", "UNKNOWN_ERROR", {}));
+
+        const error = await errorReceived;
+        assert.ok(error, "error event should have been emitted");
+        assert.ok(error.message.includes("failed to subscribe"),
+            `error message should mention subscribe failure, got: ${error.message}`);
+
+        // Let microtasks settle to catch any stray unhandled rejections
+        await new Promise((r) => setTimeout(r, 100));
+    });
+
+    it("should not throw when stop is called on a failed subscription", async function () {
+        this.timeout(5000);
+
+        const provider = new MockSocketProvider();
+        provider.init();
+
+        const sub = new SocketBlockSubscriber(provider as any);
+        sub.start();
+
+        await new Promise((r) => setTimeout(r, 50));
+
+        const payloadId = provider._lastPayload!.id;
+
+        provider.on("error", () => { /* expected */ });
+
+        provider.rejectTo(payloadId, makeError("subscription rejected", "UNKNOWN_ERROR", {}));
+
+        await new Promise((r) => setTimeout(r, 50));
+
+        assert.doesNotThrow(() => {
+            sub.stop();
+        });
+
+        await new Promise((r) => setTimeout(r, 100));
+    });
+
+    it("should not send eth_unsubscribe when subscription failed", async function () {
+        this.timeout(5000);
+
+        const provider = new MockSocketProvider();
+        provider.init();
+
+        const sub = new SocketBlockSubscriber(provider as any);
+        sub.start();
+
+        await new Promise((r) => setTimeout(r, 50));
+
+        const payloadId = provider._lastPayload!.id;
+        provider.on("error", () => { /* expected */ });
+        provider.rejectTo(payloadId, makeError("subscription rejected", "UNKNOWN_ERROR", {}));
+
+        await new Promise((r) => setTimeout(r, 50));
+
+        // Clear last payload so we can detect if stop() sends anything
+        provider._lastPayload = null;
+
+        sub.stop();
+
+        await new Promise((r) => setTimeout(r, 100));
+
+        // No eth_unsubscribe should have been sent
+        assert.equal(provider._lastPayload, null,
+            "stop() should not send eth_unsubscribe for a failed subscription");
+    });
+});

--- a/src.ts/providers/provider-socket.ts
+++ b/src.ts/providers/provider-socket.ts
@@ -61,17 +61,26 @@ export class SocketSubscriber implements Subscriber {
     }
 
     start(): void {
-        this.#filterId = this.#provider.send("eth_subscribe", this.filter).then((filterId) => {;
+        const promise = this.#provider.send("eth_subscribe", this.filter).then((filterId) => {
             this.#provider._register(filterId, this);
             return filterId;
+        }, (error) => {
+            if (this.#filterId === promise) { this.#filterId = null; }
+            this.#provider.emit("error", makeError("failed to subscribe", "UNKNOWN_ERROR", {
+                error, info: { filter: this.filter }
+            }));
+            return null as any;
         });
+        this.#filterId = promise;
     }
 
     stop(): void {
-        (<Promise<number>>(this.#filterId)).then((filterId) => {
-            if (this.#provider.destroyed) { return; }
-            this.#provider.send("eth_unsubscribe", [ filterId ]);
-        });
+        if (this.#filterId != null) {
+            this.#filterId.then((filterId) => {
+                if (filterId == null || this.#provider.destroyed) { return; }
+                this.#provider.send("eth_unsubscribe", [ filterId ]);
+            }).catch(() => { });
+        }
         this.#filterId = null;
     }
 


### PR DESCRIPTION
## Problem

`SocketSubscriber.start()` stores the `eth_subscribe` promise with only a `.then()` handler (line 64, `provider-socket.ts`). When a provider returns a JSON-RPC error to `eth_subscribe` (auth failure, 5xx, unsupported method), the rejection has no handler and becomes an **uncatchable unhandled rejection** that crashes the process.

`try/catch` around `contract.on()` or `provider.on()` cannot intercept it because `start()` returns `void` and `#filterId` is private. `process.on('unhandledRejection')` is the only place it surfaces.

This also affects `stop()`, which unconditionally calls `.then()` on `#filterId` without a null check or `.catch()`.

Closes #5178

## Fix

**`start()`:**
- Uses `.then(onFulfilled, onRejected)` instead of a detached `.catch()` chain (a `.catch()` that re-throws would create a *new* unhandled rejection on the returned promise)
- `onRejected` routes the error to the provider's `"error"` event, matching the existing ethers convention (`provider-jsonrpc.ts` line 564, `provider-socket.ts` line 312/337)
- Resets `#filterId` only when it still points to the current promise (identity guard — prevents a stale rejection handler from clobbering a subsequent `start()`)
- Returns `null` to absorb the rejection

**`stop()`:**
- Adds null check on `#filterId` before calling `.then()` (prevents NPE when subscription already failed)
- Guards against sending `eth_unsubscribe` with a null filter ID
- Adds `.catch(() => {})` to swallow rejections from the unsubscribe send

Also fixes a minor typo on the original line 64: `{;` → `{`

## Test plan

Added `test-providers-socket-subscribe.ts` with 3 tests, each with an `unhandledRejection` process listener that fails the test if any unhandled rejection occurs:

- [x] `eth_subscribe` rejection emits provider `"error"` event with correct message
- [x] `stop()` on a failed subscription does not throw
- [x] `stop()` on a failed subscription does not send `eth_unsubscribe`

All existing tests pass (`test-providers-jsonrpc` 2/2).