### PR TITLE
fix: set fromBlock latest on eth_newFilter for event listeners

### DIFF
--- a/src.ts/_tests/test-providers-jsonrpc.ts
+++ b/src.ts/_tests/test-providers-jsonrpc.ts
@@ -205,3 +205,49 @@ describe("Ensure Catchable Errors", function() {
     });
 });
 
+describe("FilterIdEventSubscriber", function() {
+    it("includes fromBlock latest on eth_newFilter when listening for events", async function() {
+        this.timeout(15000);
+
+        let newFilterParams: any = null;
+        const provider = createProvider((method, params) => {
+            switch (method) {
+                case "eth_newFilter":
+                    newFilterParams = (params as any)[0];
+                    return "0x01";
+                case "eth_getFilterChanges":
+                    return [ ];
+                case "eth_uninstallFilter":
+                    return true;
+            }
+            return undefined;
+        });
+
+        const address = "0x8909dc15e40173ff4699343b6eb8132c65e18ec6";
+        const handler = () => { };
+        await new Promise<void>((resolve, reject) => {
+            const timer = setTimeout(() => {
+                reject(new Error("timed out waiting for eth_newFilter"));
+            }, 5000);
+            provider.on({ address }, handler);
+            const check = () => {
+                if (newFilterParams != null) {
+                    clearTimeout(timer);
+                    resolve();
+                    return;
+                }
+                setTimeout(check, 20);
+            };
+            check();
+        });
+
+        assert.equal(newFilterParams.fromBlock, "latest");
+        const filterAddress = Array.isArray(newFilterParams.address)
+            ? newFilterParams.address[0]
+            : newFilterParams.address;
+        assert.equal(String(filterAddress).toLowerCase(), address);
+
+        provider.off({ address }, handler);
+    });
+});
+

--- a/src.ts/providers/subscriber-filterid.ts
+++ b/src.ts/providers/subscriber-filterid.ts
@@ -170,7 +170,15 @@ export class FilterIdEventSubscriber extends FilterIdSubscriber {
     }
 
     async _subscribe(provider: JsonRpcApiProvider): Promise<string> {
-        const filterId = await provider.send("eth_newFilter", [ this.#event ]);
+        const filter: Record<string, any> = copy(this.#event);
+        // eth_newFilter defaults fromBlock to "latest" in the JSON-RPC spec.
+        // Some providers (e.g. Chainstack) reject a missing fromBlock as an
+        // unbounded historical range. Make the default explicit so live
+        // listeners do not hit those limits. See #5061.
+        if (filter.fromBlock == null) {
+            filter.fromBlock = "latest";
+        }
+        const filterId = await provider.send("eth_newFilter", [ filter ]);
         return filterId;
     }
 


### PR DESCRIPTION
Fixes #5061.

`FilterIdEventSubscriber` sends `eth_newFilter` with only `address` and `topics`. The JSON-RPC spec defaults `fromBlock` to `latest`, but some providers (Chainstack and others with historical range limits) treat a missing `fromBlock` as an unbounded range and reject the request. That makes `contract.on()` / `provider.on(filter)` fail even though the listener only needs new logs.

When the filter does not already specify `fromBlock`, this sets `fromBlock: "latest"` so live subscriptions match the spec default and those providers.

Existing explicit `fromBlock` values are left unchanged. Test uses the in-process JsonRpc mock from `test-providers-jsonrpc.ts`.
