### PR TITLE
fix: handle socket subscription errors

### DIFF
--- a/src.ts/providers/provider-socket.ts
+++ b/src.ts/providers/provider-socket.ts
@@ -65,6 +65,10 @@ export class SocketSubscriber implements Subscriber {
             this.#provider._register(filterId, this);
             return filterId;
         });
+        this.#filterId.catch((error) => {
+            this.#filterId = null;
+            this.#provider.emit("error", error);
+        });
     }
 
     stop(): void {


### PR DESCRIPTION
## Summary

Fixes #5178.

Attach a rejection handler to `SocketSubscriber.start()` after the `eth_subscribe` request is created. Failed subscription requests now clear the subscriber state and emit the error through the provider error event, preventing an unhandled rejection while preserving the existing API.

## Validation

- `git diff --check` passed.
- - The repository dependency tree did not include the local TypeScript binary, so the build was unavailable in the sandbox.