### PR TITLE
fix: fix HTTP client reallocating buffer at every chunk

### DIFF
--- a/src.ts/utils/geturl.ts
+++ b/src.ts/utils/geturl.ts
@@ -79,6 +79,7 @@ export function createGetUrl(options?: Record<string, any>): FetchGetUrlFunc {
                 }, <{ [ name: string ]: string }>{ });
 
                 let body: null | Uint8Array = null;
+                const chunks: Array<Uint8Array> = [ ];
                 //resp.setEncoding("utf8");
 
                 resp.on("data", (chunk: Uint8Array) => {
@@ -90,18 +91,15 @@ export function createGetUrl(options?: Record<string, any>): FetchGetUrlFunc {
                         }
                     }
 
-                    if (body == null) {
-                        body = chunk;
-                    } else {
-                        const newBody = new Uint8Array(body.length + chunk.length);
-                        newBody.set(body, 0);
-                        newBody.set(chunk, body.length);
-                        body = newBody;
-                    }
+                    chunks.push(chunk);
                 });
 
                 resp.on("end", () => {
                     try {
+                        if (chunks.length) {
+                            body = getBytes(Buffer.concat(chunks));
+                        }
+
                         if (headers["content-encoding"] === "gzip" && body) {
                             body = getBytes(gunzipSync(body));
                         }


### PR DESCRIPTION
## Summary
The `getUrl` implementation grows the response body by allocating a new `Uint8Array` and copying **the entire accumulated buffer on every `data` event**. That is O(n²) in the number of chunks (CPU / memcpy). For a large JSON-RPC body this stalls the event loop for seconds on node.js. This change collects chunks and concatenates them once with `Buffer.concat` on `end`. Empty responses still resolve with `body: null`. Gzip handling is unchanged.

## Real-world numbers
This has high impact on large payloads, for instance `debug_traceBlockByNumber`. A CPU profile scoped to a single HTTP block fetching request:
| | |
|---|---|
| Payload | **33.2 MB** |
| Request wall time | **15.8 s** |
| Time in `geturl.js` `data` handler | **10.5 s (62.6%)** | | GC | 1.3 s (7.7%) |
| `JSON.parse` of the same body | **94 ms** |

With ~64KB socket chunks that is ~520 reallocations and on the order of **8 GB of memcpy**, all on the JS thread. A local replay of the same 33.2MB payload (isolating CPU from upstream RTT):
| | Wall | Max event-loop stall | Max 10ms heartbeat gap |
|---|---:|---:|---:|
| Current (copy on every chunk) | 4202ms | 273ms | 263ms | | `Buffer.concat` once | 1892ms | 5ms | 2ms |