### PR TITLE
feat: expose Signature._yParity for non-canonical authorization values

### DIFF
--- a/src.ts/crypto/signature.ts
+++ b/src.ts/crypto/signature.ts
@@ -36,18 +36,18 @@ export type SignatureLike = Signature | string | {
     r: string;
     s: string;
     v: BigNumberish;
-    yParity?: 0 | 1;
+    yParity?: number;
     yParityAndS?: string;
 } | {
     r: string;
     yParityAndS: string;
-    yParity?: 0 | 1;
+    yParity?: number;
     s?: string;
     v?: number;
 } | {
     r: string;
     s: string;
-    yParity: 0 | 1;
+    yParity: number;
     v?: BigNumberish;
     yParityAndS?: string;
 };
@@ -67,6 +67,7 @@ export class Signature {
     #s: string;
     #v: 27 | 28;
     #networkV: null | bigint;
+    #yParity: number;
 
     /**
      *  The ``r`` value for a signature.
@@ -107,7 +108,7 @@ export class Signature {
      */
     isValid(): boolean {
         const s = BigInt(this.#s);
-        return (s <= BN_N_2);
+        return (s <= BN_N_2) && (this.#yParity === 0 || this.#yParity === 1);
     }
 
     /**
@@ -147,10 +148,23 @@ export class Signature {
      *  The ``yParity`` for the signature.
      *
      *  See ``v`` for more details on how this value is used.
+     *
+     *  This asserts the value is ``0`` or ``1``. For a possibly
+     *  non-canonical value (for example an Authorization List entry),
+     *  use [[Signature-_yParity]].
      */
     get yParity(): 0 | 1 {
-        return (this.v === 27) ? 0: 1;
+        assertArgument(this.#yParity === 0 || this.#yParity === 1, "non-canonical yParity; use ._yParity", "yParity", this.#yParity);
+        return <0 | 1>this.#yParity;
     }
+
+    /**
+     *  Return the yParity value without requiring it to be ``0`` or ``1``.
+     *
+     *  Prefer [[Signature-yParity]] unless you need the raw wire value,
+     *  such as when re-encoding Authorization List signatures for attestation.
+     */
+    get _yParity(): number { return this.#yParity; }
 
     /**
      *  The [[link-eip-2098]] compact representation of the ``yParity``
@@ -180,12 +194,13 @@ export class Signature {
     /**
      *  @private
      */
-    constructor(guard: any, r: string, s: string, v: 27 | 28) {
+    constructor(guard: any, r: string, s: string, v: 27 | 28, yParity?: number) {
         assertPrivate(guard, _guard, "Signature");
         this.#r = r;
         this.#s = s;
         this.#v = v;
         this.#networkV = null;
+        this.#yParity = (yParity != null) ? yParity : ((v === 27) ? 0 : 1);
     }
 
     /**
@@ -213,7 +228,7 @@ export class Signature {
      *  Returns a new identical [[Signature]].
      */
     clone(): Signature {
-        const clone = new Signature(_guard, this.r, this._s, this.v);
+        const clone = new Signature(_guard, this.r, this._s, this.v, this.#yParity);
         if (this.networkV) { clone.#networkV = this.networkV; }
         return clone;
     }
@@ -226,7 +241,7 @@ export class Signature {
         return {
             _type: "signature",
             networkV: ((networkV != null) ? networkV.toString(): null),
-            r: this.r, s: this._s, v: this.v,
+            r: this.r, s: this._s, v: this.v, yParity: this.#yParity,
         };
     }
 
@@ -373,6 +388,7 @@ export class Signature {
         })(sig.s, sig.yParityAndS);
 
         // Get v; by any means necessary (we check consistency below)
+        let yParityRaw: number | undefined = (sig.yParity != null) ? getNumber(sig.yParity, "sig.yParity"): undefined;
         const { networkV, v } = (function(_v?: BigNumberish, yParityAndS?: string, yParity?: Numeric): { networkV?: bigint, v: 27 | 28 } {
             if (_v != null) {
                 const v = getBigInt(_v);
@@ -388,21 +404,21 @@ export class Signature {
             }
 
             if (yParity != null) {
-                switch (getNumber(yParity, "sig.yParity")) {
-                    case 0: return { v: 27 };
-                    case 1: return { v: 28 };
-                }
-                assertError(false, "invalid yParity");
+                const yp = getNumber(yParity, "sig.yParity");
+                if (yp === 0 || yp === 27) { return { v: 27 }; }
+                if (yp === 1 || yp === 28) { return { v: 28 }; }
+                // Preserve non-canonical yParity for ._yParity (Authorization List / attestation).
+                return { v: ((yp & 1) ? 28: 27) };
             }
 
             assertError(false, "missing v");
         })(sig.v, sig.yParityAndS, sig.yParity);
 
-        const result = new Signature(_guard, r, s, v);
+        const result = new Signature(_guard, r, s, v, yParityRaw);
         if (networkV) { result.#networkV =  networkV; }
 
         // If multiple of v, yParity, yParityAndS we given, check they match
-        assertError(sig.yParity == null || getNumber(sig.yParity, "sig.yParity") === result.yParity, "yParity mismatch");
+        assertError(sig.yParity == null || getNumber(sig.yParity, "sig.yParity") === result._yParity, "yParity mismatch");
         assertError(sig.yParityAndS == null || sig.yParityAndS === result.yParityAndS, "yParityAndS mismatch");
 
         return result;

--- a/src.ts/transaction/transaction.ts
+++ b/src.ts/transaction/transaction.ts
@@ -317,7 +317,7 @@ function handleAuthorizationList(value: any, param: string): Array<Authorization
                 nonce: handleUint(auth[2], "nonce"),
                 chainId: handleUint(auth[0], "chainId"),
                 signature: Signature.from({
-                    yParity: <0 | 1>handleNumber(auth[3], "yParity"),
+                    yParity: handleNumber(auth[3], "yParity"),
                     r: zeroPadValue(auth[4], 32),
                     s: zeroPadValue(auth[5], 32)
                 })
@@ -358,7 +358,7 @@ function formatAuthorizationList(value: Array<Authorization>): Array<Array<strin
             formatNumber(a.chainId, "chainId"),
             a.address,
             formatNumber(a.nonce, "nonce"),
-            formatNumber(a.signature.yParity, "yParity"),
+            formatNumber(a.signature._yParity, "yParity"),
             toBeArray(a.signature.r),
             toBeArray(a.signature._s)
         ];


### PR DESCRIPTION
## Summary

Authorization List (and attestation) flows sometimes need the raw yParity from the wire, including values outside `0` / `1`. Today `Signature.yParity` always normalizes through `v`, and `Signature.from({ yParity })` rejected anything other than `0` or `1`.

ricmoo noted on #5091 that exposing a non-normalized `._yParity` (mirroring `._s`) makes sense, with `.yParity` staying strict and serialization using the raw value.

## Changes

- Store raw yParity on `Signature` and expose `._yParity`.
- `.yParity` asserts the value is `0` or `1` (same idea as `.s` vs `._s`).
- `isValid()` also requires canonical yParity.
- `Signature.from` accepts non-canonical yParity and preserves it for `._yParity`.
- Authorization List encode/decode uses `._yParity` / raw `handleNumber` so round-trips keep the wire value.
- Widen `SignatureLike.yParity` to `number`.

## Test plan

- [ ] Existing crypto / transaction tests in CI
- [ ] Manual: `Signature.from({ r, s, yParity: 27 })._yParity === 27` and `.yParity` throws; auth list RLP round-trip keeps non-0/1 yParity

Fixes #5091