### PR TITLE
docs: point README API Keys link at v6 getting-started

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ responses, more capacity, analytics and other features like archival
 data.
 
 When you are ready to sign up and start using for your own keys, please
-check out the [Provider API Keys](https://docs.ethers.org/v5/api-keys/) in
+check out the [Provider API Keys](https://docs.ethers.org/v6/getting-started/#getting-started--api-keys) in
 the documentation.
 
 A special thanks to these services for providing community resources:


### PR DESCRIPTION
## Summary
The published package is ethers **6.17.0**, and other README docs links already point at `/v6/`, but the Providers section still links **Provider API Keys** to the v5 docs (`https://docs.ethers.org/v5/api-keys/`).

`/v6/api-keys/` 404s. The current v6 docs live under Getting Started:

`https://docs.ethers.org/v6/getting-started/#getting-started--api-keys` (HTTP 200)

This PR retargets that single README link only.

## Repro
1. Open `README.md` on `main` @ `3ea4c226dd0b` → Providers section links `https://docs.ethers.org/v5/api-keys/`
2. Confirm `package.json` version is `6.17.0` and other README docs URLs use `/v6/`
3. `https://docs.ethers.org/v6/api-keys/` → 404
4. `https://docs.ethers.org/v6/getting-started/#getting-started--api-keys` → 200

## Test plan
- [ ] Diff is one-line URL change in README.md
- [ ] New link returns 200 and lands on API Keys guidance

